### PR TITLE
Implement two-sided lending agreements with invites

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -26,6 +26,8 @@
     .row input{flex:1; padding:10px 12px; border-radius:10px; border:1px solid rgba(255,255,255,0.08); background:#10151d; color:var(--text)}
     button{padding:10px 14px;border-radius:10px;border:0;background:var(--accent);color:#0d130f;font-weight:700; cursor:pointer}
     button:hover{filter:brightness(1.06)}
+    button.secondary{background:transparent; border:1px solid rgba(255,255,255,0.15); color:var(--text); margin-left:8px}
+    button.secondary:hover{background:rgba(255,255,255,0.05)}
     .tabs{display:flex; gap:8px; margin-bottom:16px; border-bottom:1px solid rgba(255,255,255,0.08)}
     .tab{padding:10px 16px; cursor:pointer; color:var(--muted); border-bottom:2px solid transparent; margin-bottom:-1px}
     .tab.active{color:var(--accent); border-bottom-color:var(--accent)}
@@ -38,11 +40,26 @@
     .status-badge.pending{background:#4a4a4a; color:#fff}
     .status-badge.active{background:#3d7bdc; color:#fff}
     .status-badge.settled{background:#3ddc97; color:#0d130f}
+    .status-badge.declined{background:#ff6b6b; color:#fff}
     .messages-list{margin-top:12px}
     .message-item{padding:10px; background:#10151d; border-radius:8px; margin:8px 0; font-size:14px}
     .message-subject{font-weight:600; margin-bottom:4px}
     .message-date{color:var(--muted); font-size:12px}
     .empty-state{text-align:center; color:var(--muted); padding:32px; font-size:14px}
+    .wizard-steps{display:flex; gap:16px; margin-bottom:24px; align-items:center}
+    .wizard-step{flex:1; padding:8px 16px; background:#10151d; border-radius:8px; text-align:center; font-size:14px; border:2px solid transparent}
+    .wizard-step.active{border-color:var(--accent); color:var(--accent); font-weight:600}
+    .wizard-step.completed{color:var(--accent)}
+    .wizard-content{min-height:200px}
+    .hidden{display:none}
+    .role-badge{display:inline-block; padding:4px 8px; border-radius:6px; font-size:11px; font-weight:600; background:#2a2a2a; color:#fff}
+    .role-badge.lend{background:#3d7bdc; color:#fff}
+    .role-badge.borrow{background:#e67e22; color:#fff}
+    .invite-url-box{background:#10151d; padding:12px; border-radius:8px; margin:16px 0; font-family:monospace; font-size:13px; word-break:break-all; border:1px solid rgba(255,255,255,0.08)}
+    .summary-row{display:flex; justify-content:space-between; padding:12px 0; border-bottom:1px solid rgba(255,255,255,0.08)}
+    .summary-row:last-child{border-bottom:none}
+    .summary-label{color:var(--muted)}
+    .summary-value{font-weight:600}
   </style>
 </head>
 <body>
@@ -68,16 +85,38 @@
       </div>
     </section>
 
+    <!-- Wizard for creating agreements -->
     <section class="card">
-      <h2>New agreement</h2>
-      <form id="form">
+      <h2>New Agreement</h2>
+
+      <!-- Wizard Steps -->
+      <div class="wizard-steps">
+        <div class="wizard-step" id="step-indicator-1">1. Role</div>
+        <div class="wizard-step" id="step-indicator-2">2. Details</div>
+        <div class="wizard-step" id="step-indicator-3">3. Summary</div>
+      </div>
+
+      <!-- Step 1: Role Selection -->
+      <div id="wizard-step-1" class="wizard-content">
+        <h3 style="margin-top:0">I want to...</h3>
+        <div style="display:flex; gap:16px; flex-wrap:wrap">
+          <button onclick="selectRole('lend')" style="flex:1; min-width:200px">Lend money to a friend</button>
+          <!-- Future: uncomment for borrow flow
+          <button onclick="selectRole('borrow')" style="flex:1; min-width:200px" disabled>Borrow money from a friend (Coming soon)</button>
+          -->
+        </div>
+      </div>
+
+      <!-- Step 2: Friend & Basic Details -->
+      <div id="wizard-step-2" class="wizard-content hidden">
+        <h3 style="margin-top:0">Friend & Agreement Details</h3>
         <div class="row">
-          <label>Lender name</label>
-          <input id="lender" placeholder="Alice" required />
+          <label>Friend's first name</label>
+          <input id="friend-first-name" placeholder="Alex" required />
         </div>
         <div class="row">
-          <label>Borrower email</label>
-          <input id="borrower" type="email" placeholder="bob@example.com" required />
+          <label>Friend's email</label>
+          <input id="friend-email" type="email" placeholder="alex@example.com" required />
         </div>
         <div class="row">
           <label>Amount (EUR)</label>
@@ -85,11 +124,58 @@
         </div>
         <div class="row">
           <label>Due date</label>
-          <input id="due" type="date" required />
+          <input id="due-date" type="date" required />
         </div>
-        <button type="submit">Create agreement</button>
-        <p id="status" class="status"></p>
-      </form>
+        <div style="margin-top:16px">
+          <button onclick="goToSummary()">Continue to Summary</button>
+          <button class="secondary" onclick="goToStep(1)">Back</button>
+        </div>
+        <p id="step2-status" class="status"></p>
+      </div>
+
+      <!-- Step 3: Summary & Send -->
+      <div id="wizard-step-3" class="wizard-content hidden">
+        <h3 style="margin-top:0">Summary</h3>
+        <div style="background:#10151d; padding:16px; border-radius:8px; margin:16px 0">
+          <div class="summary-row">
+            <span class="summary-label">You are</span>
+            <span class="summary-value">Lending</span>
+          </div>
+          <div class="summary-row">
+            <span class="summary-label">Amount</span>
+            <span class="summary-value" id="summary-amount">€0.00</span>
+          </div>
+          <div class="summary-row">
+            <span class="summary-label">To</span>
+            <span class="summary-value" id="summary-friend"></span>
+          </div>
+          <div class="summary-row">
+            <span class="summary-label">Friend email</span>
+            <span class="summary-value" id="summary-email"></span>
+          </div>
+          <div class="summary-row">
+            <span class="summary-label">Repayment</span>
+            <span class="summary-value">One payment on <span id="summary-due"></span></span>
+          </div>
+        </div>
+
+        <div id="invite-not-sent">
+          <button onclick="sendInvite()">Send to <span id="send-friend-name"></span> for review</button>
+          <button class="secondary" onclick="goToStep(2)">Back</button>
+        </div>
+
+        <div id="invite-sent" class="hidden">
+          <div style="background:rgba(61,220,151,0.1); border:1px solid rgba(61,220,151,0.2); border-radius:8px; padding:12px; margin:16px 0">
+            <p style="margin:0; color:var(--accent); font-weight:600">Invite sent!</p>
+          </div>
+          <p style="color:var(--muted); font-size:14px">Share this invite link with your friend:</p>
+          <div class="invite-url-box" id="invite-url"></div>
+          <button onclick="copyInviteUrl()">Copy invite link</button>
+          <button class="secondary" onclick="resetWizard()">Create another agreement</button>
+        </div>
+
+        <p id="step3-status" class="status"></p>
+      </div>
     </section>
 
     <section class="card">
@@ -108,11 +194,11 @@
         <thead>
           <tr>
             <th>ID</th>
+            <th>Role</th>
             <th>Lender</th>
             <th>Borrower</th>
             <th>Amount</th>
             <th>Due</th>
-            <th>Created</th>
             <th>Status</th>
             <th>Actions</th>
           </tr>
@@ -129,6 +215,135 @@
     let allAgreements = [];
     let currentFilter = 'all';
     let currentUser = null;
+    let wizardData = {
+      role: null,
+      friendFirstName: '',
+      friendEmail: '',
+      amount: '',
+      dueDate: '',
+      inviteUrl: ''
+    };
+
+    // Wizard functions
+    function goToStep(step) {
+      // Hide all steps
+      for (let i = 1; i <= 3; i++) {
+        document.getElementById(`wizard-step-${i}`).classList.add('hidden');
+        document.getElementById(`step-indicator-${i}`).classList.remove('active');
+      }
+
+      // Show current step
+      document.getElementById(`wizard-step-${step}`).classList.remove('hidden');
+      document.getElementById(`step-indicator-${step}`).classList.add('active');
+
+      // Mark previous steps as completed
+      for (let i = 1; i < step; i++) {
+        document.getElementById(`step-indicator-${i}`).classList.add('completed');
+      }
+    }
+
+    function selectRole(role) {
+      wizardData.role = role;
+      goToStep(2);
+    }
+
+    function goToSummary() {
+      const friendFirstName = document.getElementById('friend-first-name').value.trim();
+      const friendEmail = document.getElementById('friend-email').value.trim();
+      const amount = document.getElementById('amount').value;
+      const dueDate = document.getElementById('due-date').value;
+      const status = document.getElementById('step2-status');
+
+      if (!friendFirstName || !friendEmail || !amount || !dueDate) {
+        status.textContent = 'Please fill in all fields';
+        return;
+      }
+
+      wizardData.friendFirstName = friendFirstName;
+      wizardData.friendEmail = friendEmail;
+      wizardData.amount = amount;
+      wizardData.dueDate = dueDate;
+
+      // Update summary
+      document.getElementById('summary-amount').textContent = `€${parseFloat(amount).toFixed(2)}`;
+      document.getElementById('summary-friend').textContent = friendFirstName;
+      document.getElementById('summary-email').textContent = friendEmail;
+      document.getElementById('summary-due').textContent = new Date(dueDate).toLocaleDateString();
+      document.getElementById('send-friend-name').textContent = friendFirstName;
+
+      goToStep(3);
+    }
+
+    async function sendInvite() {
+      const status = document.getElementById('step3-status');
+      status.textContent = 'Creating agreement...';
+
+      try {
+        const res = await fetch('/api/agreements', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            friendFirstName: wizardData.friendFirstName,
+            borrowerEmail: wizardData.friendEmail,
+            amount: wizardData.amount,
+            dueDate: wizardData.dueDate,
+            direction: wizardData.role,
+            repaymentType: 'one_time'
+          })
+        });
+
+        const data = await res.json();
+        if (!res.ok) throw new Error(data.error || 'Failed');
+
+        wizardData.inviteUrl = data.inviteUrl;
+        document.getElementById('invite-url').textContent = data.inviteUrl;
+
+        // Hide send button, show invite URL
+        document.getElementById('invite-not-sent').classList.add('hidden');
+        document.getElementById('invite-sent').classList.remove('hidden');
+
+        status.textContent = '';
+        refresh();
+        loadMessages();
+      } catch (err) {
+        status.textContent = '❌ ' + err.message;
+      }
+    }
+
+    function copyInviteUrl() {
+      const url = wizardData.inviteUrl;
+      navigator.clipboard.writeText(url).then(() => {
+        document.getElementById('step3-status').textContent = '✅ Copied to clipboard!';
+        setTimeout(() => {
+          document.getElementById('step3-status').textContent = '';
+        }, 2000);
+      }).catch(() => {
+        document.getElementById('step3-status').textContent = '❌ Failed to copy';
+      });
+    }
+
+    function resetWizard() {
+      wizardData = {
+        role: null,
+        friendFirstName: '',
+        friendEmail: '',
+        amount: '',
+        dueDate: '',
+        inviteUrl: ''
+      };
+
+      document.getElementById('friend-first-name').value = '';
+      document.getElementById('friend-email').value = '';
+      document.getElementById('amount').value = '';
+      document.getElementById('due-date').value = '';
+      document.getElementById('step2-status').textContent = '';
+      document.getElementById('step3-status').textContent = '';
+
+      document.getElementById('invite-not-sent').classList.remove('hidden');
+      document.getElementById('invite-sent').classList.add('hidden');
+
+      goToStep(1);
+    }
 
     // Fetch current user
     async function loadUser() {
@@ -249,17 +464,25 @@
         const statusText = a.status || 'pending';
         const statusBadge = `<span class="status-badge ${statusText}">${statusText}</span>`;
 
-        const actionBtn = (statusText === 'active' || statusText === 'pending')
+        // Determine role
+        const isLender = a.lender_user_id === currentUser.id;
+        const role = isLender ? 'You lent' : 'You borrowed';
+        const roleBadge = `<span class="role-badge ${isLender ? 'lend' : 'borrow'}">${role}</span>`;
+
+        // Determine borrower name
+        const borrowerName = a.friend_first_name || a.borrower_email;
+
+        const actionBtn = (statusText === 'active' && isLender)
           ? `<button onclick="markAsPaid(${a.id})">Mark as Paid</button>`
           : '—';
 
         tr.innerHTML = `
           <td>${a.id}</td>
+          <td>${roleBadge}</td>
           <td>${a.lender_name}</td>
-          <td>${a.borrower_email}</td>
+          <td>${borrowerName}</td>
           <td>€ ${amount}</td>
           <td>${a.due_date}</td>
-          <td>${new Date(a.created_at).toLocaleString()}</td>
           <td>${statusBadge}</td>
           <td>${actionBtn}</td>
         `;
@@ -278,37 +501,11 @@
       }
     }
 
-    // Create agreement form
-    document.getElementById('form').addEventListener('submit', async (e) => {
-      e.preventDefault();
-      const lenderName = document.getElementById('lender').value.trim();
-      const borrowerEmail = document.getElementById('borrower').value.trim();
-      const amount = document.getElementById('amount').value;
-      const dueDate = document.getElementById('due').value;
-      const status = document.getElementById('status');
-
-      status.textContent = 'Creating...';
-
-      try {
-        const res = await fetch('/api/agreements', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ lenderName, borrowerEmail, amount, dueDate })
-        });
-        const data = await res.json();
-        if (!res.ok) throw new Error(data.error || 'Failed');
-        status.textContent = '✅ Agreement created';
-        e.target.reset();
-        refresh();
-      } catch (err) {
-        status.textContent = '❌ ' + err.message;
-      }
-    });
-
     // Initialize
     loadUser();
     refresh();
     loadMessages();
+    goToStep(1);
   </script>
 </body>
 </html>

--- a/public/review-invalid.html
+++ b/public/review-invalid.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>PayFriends — Invalid Invite</title>
+  <style>
+    :root{
+      --bg:#0e1116; --card:#151a21; --text:#e6eef6; --muted:#a7b0bd; --accent:#3ddc97;
+    }
+    *{box-sizing:border-box}
+    body{margin:0; font-family:system-ui,-apple-system,Segoe UI,Arial,sans-serif; background:var(--bg); color:var(--text); display:flex; align-items:center; justify-content:center; min-height:100vh;}
+    .container{max-width:500px; padding:32px;}
+    .card{background:var(--card); border:1px solid rgba(255,255,255,0.06); border-radius:16px; padding:32px; text-align:center;}
+    h1{margin:0 0 16px 0; font-size:24px;}
+    p{color:var(--muted); line-height:1.6; margin:16px 0;}
+    .back-link{display:inline-block; margin-top:24px; padding:10px 20px; background:var(--accent); color:#0d130f; border-radius:10px; text-decoration:none; font-weight:600;}
+    .back-link:hover{filter:brightness(1.06)}
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="card">
+      <h1>Invalid Invite Link</h1>
+      <p>This invite link is invalid or has expired. Please check the link or contact the person who sent it.</p>
+      <a href="/" class="back-link">Go to Login</a>
+    </div>
+  </div>
+</body>
+</html>

--- a/public/review.html
+++ b/public/review.html
@@ -1,0 +1,318 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>PayFriends — Review Agreement</title>
+  <style>
+    :root{
+      --bg:#0e1116; --card:#151a21; --text:#e6eef6; --muted:#a7b0bd; --accent:#3ddc97;
+    }
+    *{box-sizing:border-box}
+    body{margin:0; font-family:system-ui,-apple-system,Segoe UI,Arial,sans-serif; background:var(--bg); color:var(--text); padding:32px 16px;}
+    .container{max-width:600px; margin:0 auto;}
+    .card{background:var(--card); border:1px solid rgba(255,255,255,0.06); border-radius:16px; padding:24px; margin:16px 0}
+    h1{margin:0 0 8px 0; font-size:24px}
+    h2{margin:0 0 16px 0; font-size:20px}
+    p{color:var(--muted); line-height:1.6; margin:8px 0}
+    .detail-row{display:flex; justify-content:space-between; padding:12px 0; border-bottom:1px solid rgba(255,255,255,0.08)}
+    .detail-row:last-child{border-bottom:none}
+    .detail-label{color:var(--muted); font-weight:500}
+    .detail-value{color:var(--text); font-weight:600}
+    .row{display:flex; gap:12px; align-items:center; margin:12px 0}
+    .row label{width:120px; color:var(--muted); font-size:14px}
+    .row input{flex:1; padding:10px 12px; border-radius:10px; border:1px solid rgba(255,255,255,0.08); background:#10151d; color:var(--text)}
+    button{padding:12px 20px; border-radius:10px; border:0; background:var(--accent); color:#0d130f; font-weight:700; cursor:pointer; font-size:14px; width:100%}
+    button:hover{filter:brightness(1.06)}
+    button.secondary{background:transparent; border:1px solid rgba(255,255,255,0.15); color:var(--text); margin-top:8px}
+    button.secondary:hover{background:rgba(255,255,255,0.05)}
+    .status{color:var(--muted); margin-top:12px; min-height:1.2em; font-size:14px}
+    .hidden{display:none}
+    .error{color:#ff6b6b}
+    .success{color:var(--accent)}
+    .amount{font-size:32px; font-weight:700; color:var(--accent); text-align:center; margin:16px 0}
+    .note{background:rgba(61,220,151,0.1); border:1px solid rgba(61,220,151,0.2); border-radius:8px; padding:12px; color:var(--text); font-size:14px; margin:16px 0}
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="card">
+      <h1>Agreement Review</h1>
+      <p id="loading-text">Loading agreement details...</p>
+    </div>
+
+    <!-- Not logged in: show signup/login flow -->
+    <div id="auth-section" class="card hidden">
+      <h2>Sign up to review this agreement</h2>
+      <p id="invite-email-notice"></p>
+
+      <div id="signup-form">
+        <div class="row">
+          <label>Full name</label>
+          <input id="full-name" type="text" placeholder="Your full name" required />
+        </div>
+        <div class="row">
+          <label>Email</label>
+          <input id="email" type="email" readonly style="opacity:0.7" />
+        </div>
+        <div class="row">
+          <label>Password</label>
+          <input id="password" type="password" placeholder="At least 6 characters" required />
+        </div>
+        <button onclick="handleSignup()">Sign up & Continue</button>
+        <p class="status" id="auth-status"></p>
+      </div>
+
+      <div style="text-align:center; margin-top:16px">
+        <p style="font-size:14px">Already have an account?</p>
+        <a href="/" style="color:var(--accent); text-decoration:none">Log in here</a>
+      </div>
+    </div>
+
+    <!-- Logged in: show agreement review -->
+    <div id="review-section" class="card hidden">
+      <h2>Agreement Details</h2>
+
+      <div class="amount" id="amount-display"></div>
+
+      <div style="margin:16px 0">
+        <div class="detail-row">
+          <span class="detail-label">From (Lender)</span>
+          <span class="detail-value" id="lender-name"></span>
+        </div>
+        <div class="detail-row">
+          <span class="detail-label">To (Borrower)</span>
+          <span class="detail-value" id="borrower-name"></span>
+        </div>
+        <div class="detail-row">
+          <span class="detail-label">Due date</span>
+          <span class="detail-value" id="due-date"></span>
+        </div>
+        <div class="detail-row">
+          <span class="detail-label">Repayment type</span>
+          <span class="detail-value" id="repayment-type"></span>
+        </div>
+      </div>
+
+      <div class="note">
+        By accepting this agreement, you confirm the terms and agree to repay the amount by the due date.
+      </div>
+
+      <button onclick="handleAccept()">Accept Agreement</button>
+      <button class="secondary" onclick="handleDecline()">Decline</button>
+      <p class="status" id="review-status"></p>
+    </div>
+
+    <!-- Already accepted/declined -->
+    <div id="already-processed" class="card hidden">
+      <h2>Agreement Already Processed</h2>
+      <p>This agreement has already been accepted or declined.</p>
+      <a href="/app" style="display:inline-block; margin-top:16px; padding:10px 20px; background:var(--accent); color:#0d130f; border-radius:10px; text-decoration:none; font-weight:600">Go to Dashboard</a>
+    </div>
+  </div>
+
+  <script>
+    let inviteData = null;
+    let currentUser = null;
+    const urlParams = new URLSearchParams(window.location.search);
+    const token = urlParams.get('token');
+
+    async function loadInviteData() {
+      try {
+        const res = await fetch(`/api/invites/${token}`);
+        if (!res.ok) {
+          window.location.href = '/review-invalid.html';
+          return;
+        }
+        inviteData = await res.json();
+
+        // Check if already processed
+        if (inviteData.invite.accepted_at || inviteData.agreement.status !== 'pending') {
+          document.getElementById('loading-text').parentElement.classList.add('hidden');
+          document.getElementById('already-processed').classList.remove('hidden');
+          return;
+        }
+
+        // Check if user is logged in
+        try {
+          const userRes = await fetch('/api/user');
+          if (userRes.ok) {
+            const userData = await userRes.json();
+            currentUser = userData.user;
+
+            // Verify email matches
+            if (currentUser.email === inviteData.invite.email) {
+              showReviewSection();
+            } else {
+              // Logged in but wrong email
+              document.getElementById('loading-text').textContent = 'This invite was sent to a different email address. Please log out and use the correct account.';
+            }
+          } else {
+            // Not logged in, show signup
+            showAuthSection();
+          }
+        } catch (err) {
+          // Not logged in, show signup
+          showAuthSection();
+        }
+      } catch (err) {
+        console.error('Error loading invite:', err);
+        window.location.href = '/review-invalid.html';
+      }
+    }
+
+    function showAuthSection() {
+      document.getElementById('loading-text').parentElement.classList.add('hidden');
+      document.getElementById('auth-section').classList.remove('hidden');
+
+      document.getElementById('invite-email-notice').textContent = `This agreement was sent to ${inviteData.invite.email}`;
+      document.getElementById('email').value = inviteData.invite.email;
+
+      // Pre-fill full name if friend_first_name is available
+      if (inviteData.agreement.friend_first_name) {
+        document.getElementById('full-name').value = inviteData.agreement.friend_first_name;
+      }
+    }
+
+    function showReviewSection() {
+      document.getElementById('loading-text').parentElement.classList.add('hidden');
+      document.getElementById('review-section').classList.remove('hidden');
+
+      const amount = (inviteData.agreement.amount_cents / 100).toFixed(2);
+      document.getElementById('amount-display').textContent = `€${amount}`;
+      document.getElementById('lender-name').textContent = inviteData.agreement.lender_name;
+
+      const borrowerName = currentUser.full_name || inviteData.agreement.friend_first_name || inviteData.invite.email;
+      document.getElementById('borrower-name').textContent = borrowerName;
+
+      document.getElementById('due-date').textContent = new Date(inviteData.agreement.due_date).toLocaleDateString();
+
+      const repaymentType = inviteData.agreement.repayment_type === 'one_time' ? 'One-time payment' : inviteData.agreement.repayment_type;
+      document.getElementById('repayment-type').textContent = repaymentType;
+    }
+
+    async function handleSignup() {
+      const fullName = document.getElementById('full-name').value.trim();
+      const email = document.getElementById('email').value.trim();
+      const password = document.getElementById('password').value;
+      const status = document.getElementById('auth-status');
+
+      if (!fullName) {
+        status.textContent = 'Full name is required';
+        status.className = 'status error';
+        return;
+      }
+
+      if (password.length < 6) {
+        status.textContent = 'Password must be at least 6 characters';
+        status.className = 'status error';
+        return;
+      }
+
+      status.textContent = 'Creating account...';
+      status.className = 'status';
+
+      try {
+        const res = await fetch('/auth/signup', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email, password, fullName })
+        });
+
+        const data = await res.json();
+
+        if (!res.ok) {
+          status.textContent = data.error || 'Signup failed';
+          status.className = 'status error';
+          return;
+        }
+
+        currentUser = data.user;
+        status.textContent = 'Account created! Loading agreement...';
+        status.className = 'status success';
+
+        // Reload to show review section
+        setTimeout(() => {
+          window.location.reload();
+        }, 500);
+      } catch (err) {
+        status.textContent = 'Error: ' + err.message;
+        status.className = 'status error';
+      }
+    }
+
+    async function handleAccept() {
+      const status = document.getElementById('review-status');
+      status.textContent = 'Accepting...';
+      status.className = 'status';
+
+      try {
+        const res = await fetch(`/api/invites/${token}/accept`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' }
+        });
+
+        const data = await res.json();
+
+        if (!res.ok) {
+          status.textContent = data.error || 'Failed to accept';
+          status.className = 'status error';
+          return;
+        }
+
+        status.textContent = 'Agreement accepted! Redirecting...';
+        status.className = 'status success';
+
+        setTimeout(() => {
+          window.location.href = '/app';
+        }, 1000);
+      } catch (err) {
+        status.textContent = 'Error: ' + err.message;
+        status.className = 'status error';
+      }
+    }
+
+    async function handleDecline() {
+      if (!confirm('Are you sure you want to decline this agreement?')) {
+        return;
+      }
+
+      const status = document.getElementById('review-status');
+      status.textContent = 'Declining...';
+      status.className = 'status';
+
+      try {
+        const res = await fetch(`/api/invites/${token}/decline`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' }
+        });
+
+        const data = await res.json();
+
+        if (!res.ok) {
+          status.textContent = data.error || 'Failed to decline';
+          status.className = 'status error';
+          return;
+        }
+
+        status.textContent = 'Agreement declined. Redirecting...';
+        status.className = 'status success';
+
+        setTimeout(() => {
+          window.location.href = '/app';
+        }, 1000);
+      } catch (err) {
+        status.textContent = 'Error: ' + err.message;
+        status.className = 'status error';
+      }
+    }
+
+    // Initialize
+    if (!token) {
+      window.location.href = '/review-invalid.html';
+    } else {
+      loadInviteData();
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
This implements a complete two-sided lending/borrowing agreement system:

## Database Changes
- Extended users table with full_name field
- Extended agreements table with:
  - borrower_user_id (links borrower account)
  - friend_first_name (borrower display name)
  - direction (lend/borrow)
  - repayment_type (one_time/installments)
- Created agreement_invites table for invite tokens and tracking
- Changed default status from 'active' to 'pending'

## New Features
- Multi-step wizard for creating lending agreements:
  1. Role selection (I want to lend)
  2. Friend details + amount + due date
  3. Summary with invite link generation
- Review flow for borrowers:
  - Invite link validation
  - Sign up with pre-filled email and required full_name
  - Agreement review screen with Accept/Decline options
- Two-sided dashboard:
  - Shows both lender and borrower agreements
  - Role badges ("You lent" / "You borrowed")
  - Status tabs (Pending/Active/Settled)
- Inbox messages for accept/decline actions

## API Changes
- POST /api/agreements now creates agreements with invites
- GET /api/agreements returns both lender and borrower agreements
- GET /api/invites/:token for fetching invite details
- POST /api/invites/:token/accept for accepting agreements
- POST /api/invites/:token/decline for declining agreements
- GET /review route for invite review page

## Breaking Changes
⚠️ Database schema changed - delete data/payfriends.db to reset

Next steps: Install support, automatic adjustments, and rescheduling.