### PR TITLE
Add lender ability to cancel pending agreements

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -41,6 +41,7 @@
     .status-badge.active{background:#3d7bdc; color:#fff}
     .status-badge.settled{background:#3ddc97; color:#0d130f}
     .status-badge.declined{background:#ff6b6b; color:#fff}
+    .status-badge.cancelled{background:#6c757d; color:#fff}
     .messages-list{margin-top:12px}
     .message-item{padding:10px; background:#10151d; border-radius:8px; margin:8px 0; font-size:14px}
     .message-subject{font-weight:600; margin-bottom:4px}
@@ -502,6 +503,10 @@
               activityText = msg.body;
             } else if (msg.event_type === 'AGREEMENT_REVIEW_LATER') {
               activityText = msg.body;
+            } else if (msg.event_type === 'AGREEMENT_CANCELLED_LENDER') {
+              activityText = msg.body;
+            } else if (msg.event_type === 'AGREEMENT_CANCELLED_BORROWER') {
+              activityText = msg.body;
             }
 
             return `
@@ -567,7 +572,12 @@
 
       let filtered = allAgreements;
       if (currentFilter !== 'all') {
-        filtered = allAgreements.filter(a => a.status === currentFilter);
+        // For Pending tab, exclude cancelled agreements
+        if (currentFilter === 'pending') {
+          filtered = allAgreements.filter(a => a.status === 'pending');
+        } else {
+          filtered = allAgreements.filter(a => a.status === currentFilter);
+        }
       }
 
       if (filtered.length === 0) {
@@ -601,11 +611,14 @@
 
         // Determine action button based on status and role
         let actionBtn = '—';
-        if (statusText === 'pending' && !isLender) {
+        if (statusText === 'cancelled') {
+          // No actions for cancelled agreements
+          actionBtn = '—';
+        } else if (statusText === 'pending' && !isLender) {
           // Borrower can review pending agreements
           actionBtn = `<button onclick="reviewAgreement(${a.id})">Review</button>`;
         } else if (statusText === 'pending' && isLender) {
-          // Lender can view pending agreements
+          // Lender can view pending agreements (and cancel)
           actionBtn = `<button onclick="viewAgreement(${a.id})">View</button>`;
         } else if (statusText === 'active' && isLender) {
           // Lender can mark active agreements as paid

--- a/public/review-details.html
+++ b/public/review-details.html
@@ -38,6 +38,7 @@
     .status-badge.active{background:#3d7bdc; color:#fff}
     .status-badge.settled{background:#3ddc97; color:#0d130f}
     .status-badge.declined{background:#ff6b6b; color:#fff}
+    .status-badge.cancelled{background:#6c757d; color:#fff}
   </style>
 </head>
 <body>
@@ -87,6 +88,15 @@
         <button onclick="handleAccept()">Accept Agreement</button>
         <button class="secondary" onclick="handleDecline()">Decline</button>
         <button class="tertiary" onclick="handleReviewLater()">Review Later</button>
+      </div>
+
+      <!-- Lender actions (only for pending agreements) -->
+      <div id="lender-actions" class="hidden">
+        <div class="note" style="background:rgba(255,107,107,0.1); border:1px solid rgba(255,107,107,0.2)">
+          <p style="margin:0; font-size:14px">This will withdraw the agreement so your friend can no longer accept it.</p>
+        </div>
+
+        <button class="secondary" onclick="handleCancel()" style="width:100%; margin-top:8px">Cancel request</button>
       </div>
 
       <!-- View-only mode (no actions) -->
@@ -164,9 +174,19 @@
 
       populateDetails();
 
-      // Show borrower actions
-      document.getElementById('borrower-actions').classList.remove('hidden');
-      document.getElementById('view-only').classList.add('hidden');
+      // Check if agreement is cancelled
+      if (agreement.status === 'cancelled') {
+        // Show cancelled message, hide all action buttons
+        document.getElementById('borrower-actions').classList.add('hidden');
+        document.getElementById('lender-actions').classList.add('hidden');
+        document.getElementById('view-only').classList.remove('hidden');
+        document.getElementById('status-text').textContent = 'no longer available. The lender cancelled the request';
+      } else {
+        // Show borrower actions
+        document.getElementById('borrower-actions').classList.remove('hidden');
+        document.getElementById('view-only').classList.add('hidden');
+        document.getElementById('lender-actions').classList.add('hidden');
+      }
     }
 
     function showViewSection() {
@@ -176,10 +196,21 @@
 
       populateDetails();
 
-      // Show view-only mode
+      // Hide borrower actions
       document.getElementById('borrower-actions').classList.add('hidden');
-      document.getElementById('view-only').classList.remove('hidden');
-      document.getElementById('status-text').textContent = agreement.status;
+
+      // Check if this is a lender viewing a pending agreement
+      const isLender = agreement.lender_user_id === currentUser.id;
+      if (isLender && agreement.status === 'pending') {
+        // Show lender actions (cancel button)
+        document.getElementById('lender-actions').classList.remove('hidden');
+        document.getElementById('view-only').classList.add('hidden');
+      } else {
+        // Show view-only mode
+        document.getElementById('lender-actions').classList.add('hidden');
+        document.getElementById('view-only').classList.remove('hidden');
+        document.getElementById('status-text').textContent = agreement.status;
+      }
     }
 
     function populateDetails() {
@@ -293,6 +324,41 @@
         }
 
         status.textContent = 'Saved! Redirecting to dashboard...';
+        status.className = 'status success';
+
+        setTimeout(() => {
+          window.location.href = '/app';
+        }, 1000);
+      } catch (err) {
+        status.textContent = 'Error: ' + err.message;
+        status.className = 'status error';
+      }
+    }
+
+    async function handleCancel() {
+      if (!confirm('Are you sure you want to cancel this agreement request? Your friend will no longer be able to accept it.')) {
+        return;
+      }
+
+      const status = document.getElementById('action-status');
+      status.textContent = 'Cancelling...';
+      status.className = 'status';
+
+      try {
+        const res = await fetch(`/api/agreements/${agreementId}/cancel`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' }
+        });
+
+        const data = await res.json();
+
+        if (!res.ok) {
+          status.textContent = data.error || 'Failed to cancel';
+          status.className = 'status error';
+          return;
+        }
+
+        status.textContent = 'Agreement cancelled. Redirecting...';
         status.className = 'status success';
 
         setTimeout(() => {

--- a/public/review.html
+++ b/public/review.html
@@ -112,6 +112,13 @@
       <p>This agreement has already been accepted or declined.</p>
       <a href="/app" style="display:inline-block; margin-top:16px; padding:10px 20px; background:var(--accent); color:#0d130f; border-radius:10px; text-decoration:none; font-weight:600">Go to Dashboard</a>
     </div>
+
+    <!-- Agreement cancelled -->
+    <div id="agreement-cancelled" class="card hidden">
+      <h2>Agreement No Longer Available</h2>
+      <p>This agreement is no longer available. The lender cancelled the request.</p>
+      <a href="/app" style="display:inline-block; margin-top:16px; padding:10px 20px; background:var(--accent); color:#0d130f; border-radius:10px; text-decoration:none; font-weight:600">Go to Dashboard</a>
+    </div>
   </div>
 
   <script>
@@ -134,6 +141,13 @@
           return;
         }
         inviteData = await res.json();
+
+        // Check if cancelled
+        if (inviteData.agreement.status === 'cancelled') {
+          document.getElementById('loading-text').parentElement.classList.add('hidden');
+          document.getElementById('agreement-cancelled').classList.remove('hidden');
+          return;
+        }
 
         // Check if already processed
         if (inviteData.invite.accepted_at || inviteData.agreement.status !== 'pending') {


### PR DESCRIPTION
- Add new 'cancelled' agreement status
- Create POST /agreements/:id/cancel endpoint for lenders
- Add "Cancel request" button on lender view page for pending agreements
- Create activity events for cancellation (lender and borrower)
- Update borrower review pages to show "no longer available" for cancelled agreements
- Update dashboard to filter cancelled agreements from Pending tab and show in All tab
- Add cancelled status badge styling (grey color)