### PR TITLE
Fix agreement UI layout and auto-link borrower agreements

### DIFF
--- a/public/review-details.html
+++ b/public/review-details.html
@@ -112,11 +112,11 @@
 
       <!-- Lender actions (only for pending agreements) -->
       <div id="lender-actions" class="hidden">
-        <div class="note" style="background:rgba(255,107,107,0.1); border:1px solid rgba(255,107,107,0.2)">
+        <button class="secondary" onclick="handleCancel()" style="width:100%">Cancel request</button>
+
+        <div class="note" style="background:rgba(255,107,107,0.1); border:1px solid rgba(255,107,107,0.2); margin-top:8px">
           <p style="margin:0; font-size:14px">This will withdraw the agreement so your friend can no longer accept it.</p>
         </div>
-
-        <button class="secondary" onclick="handleCancel()" style="width:100%; margin-top:8px">Cancel request</button>
       </div>
 
       <!-- View-only mode (no actions) -->

--- a/server.js
+++ b/server.js
@@ -353,6 +353,9 @@ app.post('/api/profile', requireAuth, (req, res) => {
 
 // List agreements for logged-in user (both as lender and borrower)
 app.get('/api/agreements', requireAuth, (req, res) => {
+  // Auto-link any pending agreements for this user
+  autoLinkPendingAgreements(req.user.id, req.user.email, req.user.full_name);
+
   const rows = db.prepare(`
     SELECT a.*,
       u_lender.full_name as lender_full_name,


### PR DESCRIPTION
Changes:
1. Move cancel warning below button on lender's pending agreement view
   - Button now appears first for better UX
   - Red helper text appears directly below with spacing

2. Auto-link borrower to new agreements without logout/login
   - Call autoLinkPendingAgreements() when GET /api/agreements is accessed
   - Borrowers now see new agreements immediately after dashboard refresh
   - No need to log out and back in when lender creates new agreement