### PR TITLE
feat: add payment proof upload, thousand separators, and improve wording

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "body-parser": "^2.2.0",
         "cookie-parser": "^1.4.7",
         "express": "^5.1.0",
-        "morgan": "^1.10.1"
+        "morgan": "^1.10.1",
+        "multer": "^2.0.2"
       }
     },
     "node_modules/accepts": {
@@ -29,6 +30,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -160,6 +167,23 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -203,6 +227,21 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "node_modules/content-disposition": {
       "version": "1.0.0",
@@ -746,6 +785,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
@@ -801,6 +852,67 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/multer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.2.tgz",
+      "integrity": "sha512-u7f2xaZ/UG8oLXHvtF/oWTRvT44p9ecwBBqTwgJVq0+4BW1g8OW01TyMEGWBHbyMOYVHXslaut7qEQ1meATXgw==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "mkdirp": "^0.5.6",
+        "object-assign": "^4.1.1",
+        "type-is": "^1.6.18",
+        "xtend": "^4.0.2"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
+    "node_modules/multer/node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/napi-build-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
@@ -846,6 +958,15 @@
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {
@@ -1265,6 +1386,14 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -1346,6 +1475,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -1375,6 +1510,15 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "body-parser": "^2.2.0",
     "cookie-parser": "^1.4.7",
     "express": "^5.1.0",
-    "morgan": "^1.10.1"
+    "morgan": "^1.10.1",
+    "multer": "^2.0.2"
   }
 }

--- a/public/review-details.html
+++ b/public/review-details.html
@@ -214,6 +214,14 @@
         <textarea id="payment-note" placeholder="Add any details about this payment..."></textarea>
       </div>
 
+      <div id="payment-proof-section" class="form-group" style="display:none">
+        <label class="form-label" for="payment-proof">Proof of payment (optional)</label>
+        <p style="color:var(--muted); font-size:12px; margin-bottom:8px">
+          Upload a screenshot, photo, or PDF of your payment if you have it.
+        </p>
+        <input type="file" id="payment-proof" accept="image/*,.pdf" style="width:100%; padding:8px; border-radius:8px; border:1px solid rgba(255,255,255,0.15); background:var(--bg); color:var(--text); font-family:inherit; font-size:14px">
+      </div>
+
       <button id="payment-submit-btn" onclick="submitPayment()">Record Payment</button>
       <button class="secondary" onclick="cancelPaymentForm()">Cancel</button>
 
@@ -832,7 +840,7 @@
           if (payment.status === 'pending') {
             statusText += `<div class="payment-recorded-by" style="color:#ff9800">Waiting for confirmation from ${lenderName}</div>`;
             if (isLender) {
-              statusBadge = '<span class="payment-status-badge pending">Pending approval</span>';
+              statusBadge = '<span class="payment-status-badge pending">Pending confirmation</span>';
             }
           } else if (payment.status === 'approved') {
             statusText += `<div class="payment-recorded-by" style="color:#3ddc97">Confirmed by ${lenderName}</div>`;
@@ -854,8 +862,21 @@
         if (isLender && payment.status === 'pending' && recordedByBorrower) {
           approvalButtons = `
             <div class="payment-approval-buttons">
-              <button onclick="approvePayment(${payment.id})" style="background:#3ddc97">Approve</button>
+              <button onclick="approvePayment(${payment.id})" style="background:#3ddc97">Confirm payment</button>
               <button onclick="declinePayment(${payment.id})" class="secondary">Decline</button>
+            </div>
+          `;
+        }
+
+        // Proof of payment viewer
+        let proofButton = '';
+        if (payment.proof_file_path) {
+          const isImage = payment.proof_mime_type && payment.proof_mime_type.startsWith('image/');
+          proofButton = `
+            <div style="margin-top:12px">
+              <button onclick="viewProofOfPayment('${payment.proof_file_path}', '${payment.proof_mime_type}', '${payment.proof_original_name || 'Proof of payment'}')" class="secondary" style="font-size:13px; padding:8px 12px">
+                📎 View proof of payment
+              </button>
             </div>
           `;
         }
@@ -873,6 +894,7 @@
             ${note}
             ${statusText}
             ${approvalButtons}
+            ${proofButton}
           </div>
         `;
       }).join('');
@@ -911,16 +933,23 @@
       // Update form header and button text based on user role
       const formHeader = document.getElementById('payment-form-header');
       const submitBtn = document.getElementById('payment-submit-btn');
+      const proofSection = document.getElementById('payment-proof-section');
 
       if (isBorrower) {
         formHeader.textContent = 'Report a Payment';
         submitBtn.textContent = 'Report Payment';
+        // Show proof upload for borrowers
+        proofSection.style.display = 'block';
       } else if (isLender) {
         formHeader.textContent = 'Add Received Payment';
         submitBtn.textContent = 'Add Payment';
+        // Hide proof upload for lenders
+        proofSection.style.display = 'none';
       } else {
         formHeader.textContent = 'Record a Payment';
         submitBtn.textContent = 'Record Payment';
+        // Hide proof upload by default
+        proofSection.style.display = 'none';
       }
 
       document.getElementById('details-section').classList.add('hidden');
@@ -939,6 +968,7 @@
       document.getElementById('payment-amount-field').value = '';
       document.getElementById('payment-method').value = '';
       document.getElementById('payment-note').value = '';
+      document.getElementById('payment-proof').value = '';
       document.getElementById('payment-status').textContent = '';
     }
 
@@ -947,6 +977,8 @@
       const amount = parseFloat(document.getElementById('payment-amount-field').value);
       const method = document.getElementById('payment-method').value || null;
       const note = document.getElementById('payment-note').value.trim() || null;
+      const proofInput = document.getElementById('payment-proof');
+      const proofFile = proofInput?.files[0];
 
       // Validate amount
       if (!amount || amount <= 0) {
@@ -955,14 +987,28 @@
         return;
       }
 
+      // Validate file size if present
+      if (proofFile && proofFile.size > 10 * 1024 * 1024) {
+        status.textContent = 'File size must be less than 10MB';
+        status.className = 'status error';
+        return;
+      }
+
       status.textContent = 'Recording payment...';
       status.className = 'status';
 
       try {
+        // Use FormData to support file upload
+        const formData = new FormData();
+        formData.append('amount', amount);
+        if (method) formData.append('method', method);
+        if (note) formData.append('note', note);
+        if (proofFile) formData.append('proof', proofFile);
+
         const res = await fetch(`/api/agreements/${agreementId}/payments`, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ amount, method, note })
+          body: formData
+          // Don't set Content-Type header - browser will set it with boundary
         });
 
         const data = await res.json();
@@ -1044,6 +1090,30 @@
       }
     }
 
+    // View proof of payment
+    function viewProofOfPayment(filePath, mimeType, fileName) {
+      const isPdf = mimeType && mimeType === 'application/pdf';
+
+      if (isPdf) {
+        // Open PDF in new tab
+        window.open(filePath, '_blank');
+      } else {
+        // Show image in modal
+        const modal = document.getElementById('proof-modal');
+        const modalImg = document.getElementById('proof-modal-img');
+        const modalCaption = document.getElementById('proof-modal-caption');
+
+        modal.style.display = 'flex';
+        modalImg.src = filePath;
+        modalCaption.textContent = fileName || 'Proof of payment';
+      }
+    }
+
+    function closeProofModal() {
+      const modal = document.getElementById('proof-modal');
+      modal.style.display = 'none';
+    }
+
     // Initialize
     if (!agreementId) {
       showError('Invalid agreement ID.');
@@ -1051,5 +1121,15 @@
       loadAgreementData();
     }
   </script>
+
+  <!-- Proof of payment modal -->
+  <div id="proof-modal" onclick="closeProofModal()" style="display:none; position:fixed; z-index:1000; left:0; top:0; width:100%; height:100%; background-color:rgba(0,0,0,0.9); align-items:center; justify-content:center; cursor:pointer">
+    <div style="max-width:90%; max-height:90%; position:relative">
+      <span onclick="closeProofModal()" style="position:absolute; top:-40px; right:0; color:#fff; font-size:35px; font-weight:bold; cursor:pointer">&times;</span>
+      <img id="proof-modal-img" style="max-width:100%; max-height:90vh; display:block; margin:auto">
+      <div id="proof-modal-caption" style="color:#ccc; text-align:center; padding:10px 0; font-size:14px"></div>
+    </div>
+  </div>
+
 </body>
 </html>


### PR DESCRIPTION
This commit implements three related improvements:

1. THOUSAND SEPARATORS FOR ALL AMOUNTS
   - Added formatAmount() helper in server.js
   - Applied consistent formatting (e.g. "€ 1.234") to all activity messages
   - All EUR amounts now use German locale formatting with thousand separators

2. PAYMENT WORDING IMPROVEMENTS
   - Changed "Pending approval" → "Pending confirmation"
   - Changed "Approve" button → "Confirm payment"
   - Improves clarity for payment review process

3. PROOF OF PAYMENT UPLOAD & VIEWER
   - Extended payments table with proof_file_path, proof_original_name, proof_mime_type
   - Installed and configured multer for file uploads (10MB limit)
   - Added optional file upload field to borrower "Report a Payment" form
   - Accepts images (JPEG, PNG, GIF, WebP) and PDFs
   - Files stored in uploads/payments/ with unique names
   - Added "View proof of payment" button in Payment History
   - Image viewer modal for previewing uploaded images
   - PDF opens in new tab
   - Proof upload only shown to borrowers (not lenders)

Technical details:
- Multer configured with file size limit and MIME type validation
- Static file serving for /uploads directory
- FormData used for multipart/form-data submission
- ALTER TABLE statements for existing databases (backwards compatible)
- Modal overlay for image viewing with close button

All changes tested and working with npm run dev.