### PR TITLE
Align Actions header above button group

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -248,7 +248,7 @@
             <th>Outstanding</th>
             <th>Due</th>
             <th>Status</th>
-            <th style="text-align:right">Actions</th>
+            <th style="text-align:right; padding-right:3rem">Actions</th>
           </tr>
         </thead>
         <tbody></tbody>


### PR DESCRIPTION
Adjusted the Actions column header to align horizontally with the start of the Manage button by adding padding-right: 3rem. This creates a more balanced visual alignment where the header text sits directly above where the button group begins, rather than being flush to the right edge.

The buttons remain right-aligned within their flex container as before.