### PR TITLE
Refine New Agreement wizard UX and copy

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -92,7 +92,7 @@
   <main class="container">
     <header class="header">
       <div class="header-left">
-        <h1><a href="/app" style="color:var(--text); text-decoration:none; cursor:pointer">My Agreements</a></h1>
+        <h1><a href="/app" style="color:var(--text); text-decoration:none; cursor:pointer">PayFriends.app</a></h1>
         <p class="user-email" id="user-email">Loading...</p>
       </div>
       <div class="header-right">
@@ -112,6 +112,43 @@
       </div>
       <div class="messages-list" id="activity-list">
         <p class="empty-state">No activity yet</p>
+      </div>
+    </section>
+
+    <section class="card">
+      <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:16px">
+        <h2 style="margin:0">My Agreements</h2>
+      </div>
+
+      <div class="tabs">
+        <div class="tab active" data-filter="all" onclick="filterByStatus('all')">All</div>
+        <div class="tab" data-filter="pending" onclick="filterByStatus('pending')">Pending</div>
+        <div class="tab" data-filter="active" onclick="filterByStatus('active')">Active</div>
+        <div class="tab" data-filter="settled" onclick="filterByStatus('settled')">Settled</div>
+      </div>
+
+      <table id="list">
+        <thead>
+          <tr>
+            <th id="counterparty-header">Counterparty</th>
+            <th>Description</th>
+            <th>Amount</th>
+            <th>Outstanding</th>
+            <th>Due</th>
+            <th>Status</th>
+            <th><span class="actions-header-text">Actions</span></th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+      <div id="empty-state" class="empty-state" style="display:none">
+        No agreements found for this filter.
+      </div>
+      <div style="display:flex; justify-content:flex-end; margin-top:16px">
+        <button id="new-agreement-btn" onclick="toggleNewAgreement()" style="display:flex; align-items:center; gap:8px; padding:12px 20px">
+          <span style="font-size:18px; font-weight:bold">+</span>
+          <span>New Agreement</span>
+        </button>
       </div>
     </section>
 
@@ -189,6 +226,12 @@
         </div>
         <p style="color:var(--muted); font-size:12px; margin:-6px 0 20px 172px">Enter the amount in euros.</p>
 
+        <div class="row">
+          <label>Money sent to borrower*</label>
+          <input id="money-sent-date" type="date" required />
+        </div>
+        <p style="color:var(--muted); font-size:12px; margin:-6px 0 20px 172px">When was or will the money be paid to the borrower?</p>
+
         <div style="margin:16px 0 24px 0">
           <label style="font-weight:600; font-size:14px; margin-bottom:8px; display:block">Repayment type*</label>
           <label style="display:flex; align-items:center; gap:8px; cursor:pointer; padding:12px; border-radius:8px; border:1px solid rgba(255,255,255,0.08); margin-bottom:8px">
@@ -228,7 +271,7 @@
           <div class="row">
             <label>First payment due*</label>
             <select id="first-payment-option" onchange="updateFirstPaymentOption()" style="flex:1; padding:10px 12px; border-radius:10px; border:1px solid rgba(255,255,255,0.08); background:#10151d; color:var(--text)">
-              <option value="1month">In 1 month (recommended)</option>
+              <option value="1month">In 1 month</option>
               <option value="2months">In 2 months</option>
               <option value="3months">In 3 months</option>
               <option value="custom">Pick a date…</option>
@@ -506,43 +549,6 @@
         </div>
 
         <p id="step5-status" class="status"></p>
-      </div>
-    </section>
-
-    <section class="card">
-      <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:16px">
-        <h2 style="margin:0">Agreements</h2>
-      </div>
-
-      <div class="tabs">
-        <div class="tab active" data-filter="all" onclick="filterByStatus('all')">All</div>
-        <div class="tab" data-filter="pending" onclick="filterByStatus('pending')">Pending</div>
-        <div class="tab" data-filter="active" onclick="filterByStatus('active')">Active</div>
-        <div class="tab" data-filter="settled" onclick="filterByStatus('settled')">Settled</div>
-      </div>
-
-      <table id="list">
-        <thead>
-          <tr>
-            <th id="counterparty-header">Counterparty</th>
-            <th>Description</th>
-            <th>Amount</th>
-            <th>Outstanding</th>
-            <th>Due</th>
-            <th>Status</th>
-            <th><span class="actions-header-text">Actions</span></th>
-          </tr>
-        </thead>
-        <tbody></tbody>
-      </table>
-      <div id="empty-state" class="empty-state" style="display:none">
-        No agreements found for this filter.
-      </div>
-      <div style="display:flex; justify-content:flex-end; margin-top:16px">
-        <button id="new-agreement-btn" onclick="toggleNewAgreement()" style="display:flex; align-items:center; gap:8px; padding:12px 20px">
-          <span style="font-size:18px; font-weight:bold">+</span>
-          <span>New Agreement</span>
-        </button>
       </div>
     </section>
 
@@ -1026,6 +1032,13 @@
         return false;
       }
 
+      // Validate money sent date
+      const moneySentDate = document.getElementById('money-sent-date').value;
+      if (!moneySentDate) {
+        status.textContent = 'Please select when money was/will be sent to borrower';
+        return false;
+      }
+
       const today = new Date();
       today.setHours(0, 0, 0, 0);
 
@@ -1071,6 +1084,7 @@
 
       // Store validated data
       wizardData.amount = amountNum;
+      wizardData.moneySentDate = moneySentDate;
 
       status.textContent = '';
       return true;
@@ -1495,6 +1509,12 @@
         <span style="font-weight:600">€${formatAmount(Math.round(wizardData.amount * 100))}</span>
       </div>`;
 
+      const moneySentDateFormatted = new Date(wizardData.moneySentDate).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
+      html += `<div style="display:flex; justify-content:space-between; padding:8px 0; border-bottom:1px solid rgba(255,255,255,0.05)">
+        <span style="color:var(--muted)">Money sent to borrower</span>
+        <span style="font-weight:600">${moneySentDateFormatted}</span>
+      </div>`;
+
       html += `<div style="display:flex; justify-content:space-between; padding:8px 0; border-bottom:1px solid rgba(255,255,255,0.05)">
         <span style="color:var(--muted)">Repayment type</span>
         <span style="font-weight:600">${wizardData.repaymentType === 'one_time' ? 'One-time payment' : 'Installments'}</span>
@@ -1755,6 +1775,7 @@
           borrowerEmail: wizardData.friendEmail,
           description: wizardData.description,
           amount: wizardData.amount,
+          moneySentDate: wizardData.moneySentDate,
           dueDate: wizardData.dueDate,
           direction: wizardData.role,
           repaymentType: wizardData.repaymentType,
@@ -1899,6 +1920,10 @@
       if (section.classList.contains('hidden')) {
         section.classList.remove('hidden');
         document.getElementById('new-agreement-btn').style.display = 'none';
+        // Scroll the wizard into view
+        setTimeout(() => {
+          section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }, 100);
       } else {
         closeNewAgreement();
       }

--- a/public/review-details.html
+++ b/public/review-details.html
@@ -140,6 +140,10 @@
           <span class="detail-label">Amount</span>
           <span class="detail-value" id="amount-display"></span>
         </div>
+        <div class="detail-row" id="money-sent-row" style="display:none">
+          <span class="detail-label">Money sent to borrower</span>
+          <span class="detail-value" id="money-sent-display"></span>
+        </div>
         <div class="detail-row" id="repayment-type-row">
           <span class="detail-label">Repayment type</span>
           <span class="detail-value" id="repayment-type-display"></span>
@@ -619,6 +623,15 @@
       document.getElementById('amount-display').textContent = `€ ${amount}`;
       document.getElementById('lender-name').textContent = lenderName;
       document.getElementById('borrower-name').textContent = borrowerName;
+
+      // Money sent to borrower (show if available)
+      if (agreement.money_sent_date) {
+        const moneySentDate = new Date(agreement.money_sent_date).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
+        document.getElementById('money-sent-display').textContent = moneySentDate;
+        document.getElementById('money-sent-row').style.display = 'flex';
+      } else {
+        document.getElementById('money-sent-row').style.display = 'none';
+      }
 
       // Repayment type
       const repaymentTypeText = repaymentType === 'installments' ? 'Installments' : 'One-time payment';

--- a/server.js
+++ b/server.js
@@ -238,6 +238,11 @@ try {
 } catch (e) {
   // Column already exists, ignore
 }
+try {
+  db.exec(`ALTER TABLE agreements ADD COLUMN money_sent_date TEXT;`);
+} catch (e) {
+  // Column already exists, ignore
+}
 
 // --- multer setup for file uploads ---
 const storage = multer.diskStorage({
@@ -772,7 +777,7 @@ app.get('/api/agreements', requireAuth, (req, res) => {
 // Create new agreement with invite (two-sided flow)
 app.post('/api/agreements', requireAuth, (req, res) => {
   let {
-    lenderName, borrowerEmail, friendFirstName, amount, dueDate, direction, repaymentType, description,
+    lenderName, borrowerEmail, friendFirstName, amount, moneySentDate, dueDate, direction, repaymentType, description,
     planLength, planUnit, installmentCount, installmentAmount, firstPaymentDate, finalDueDate,
     interestRate, totalInterest, totalRepayAmount,
     paymentPreferenceMethod, paymentOtherDescription, reminderMode, reminderOffsets,
@@ -828,13 +833,13 @@ app.post('/api/agreements', requireAuth, (req, res) => {
     const agreementStmt = db.prepare(`
       INSERT INTO agreements (
         lender_user_id, lender_name, borrower_email, friend_first_name,
-        direction, repayment_type, amount_cents, due_date, created_at, status, description,
+        direction, repayment_type, amount_cents, money_sent_date, due_date, created_at, status, description,
         plan_length, plan_unit, installment_count, installment_amount, first_payment_date, final_due_date,
         interest_rate, total_interest, total_repay_amount,
         payment_preference_method, payment_other_description, reminder_mode, reminder_offsets,
         proof_required, debt_collection_clause
       )
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
 
     const agreementInfo = agreementStmt.run(
@@ -845,6 +850,7 @@ app.post('/api/agreements', requireAuth, (req, res) => {
       direction || 'lend',
       repaymentType || 'one_time',
       amountCents,
+      moneySentDate || null,
       dueDate,
       createdAt,
       description,


### PR DESCRIPTION
This commit implements several UX improvements to the New Agreement wizard and agreements page:

1. Page titles:
   - Changed header title from "My Agreements" to "PayFriends.app"
   - Changed agreements table card title to "My Agreements"

2. Money sent to borrower field:
   - Added new date field in Step 2 to capture when money was/will be sent to borrower
   - Field allows past or future dates (no restriction)
   - Displayed in Step 5 summary and borrower review page
   - Stored in database as money_sent_date

3. First payment options:
   - Removed "(recommended)" suffix from "In 1 month" option

4. Amortization schedule labels:
   - Verified all user-facing labels use friendly language
   - No "Amortization schedule" text shown to users
   - Uses "Interest & payment calculation" and "Installment schedule" instead

5. Wizard placement:
   - Moved New Agreement wizard section to render below agreements table
   - Wizard now appears near the "+ New Agreement" button when opened
   - Added smooth scroll to bring wizard into view when opened

All changes maintain existing functionality while improving UX and allowing users to enter historical loan data.