### PR TITLE
Polish dashboard header, status styling, and agreement pages

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -42,6 +42,13 @@
     .status-badge.settled{background:#3ddc97; color:#0d130f}
     .status-badge.declined{background:#ff6b6b; color:#fff}
     .status-badge.cancelled{background:#6c757d; color:#fff}
+    .status-text{font-size:14px; font-weight:400}
+    .status-text.active{color:#22c55e}
+    .status-text.pending{color:#facc15}
+    .status-text.overdue{color:#f87171}
+    .status-text.settled{color:#9ca3af}
+    .status-text.cancelled{color:#9ca3af}
+    .status-text.declined{color:#f87171}
     .actions-column{display:flex; flex-wrap:wrap; gap:8px; align-items:center; justify-content:flex-end; width:100%}
     .actions-column button{flex:0 0 auto; padding:8px 12px; font-size:13px; white-space:nowrap; width:auto}
     .btn-confirm-payment{background:#f97316; color:#fff; border:0; padding:8px 12px; border-radius:8px; font-weight:600; cursor:pointer; font-size:13px}
@@ -92,7 +99,10 @@
   <main class="container">
     <header class="header">
       <div class="header-left">
-        <h1><a href="/app" style="color:var(--text); text-decoration:none; cursor:pointer">PayFriends.app</a></h1>
+        <h1 style="display:flex; align-items:center; gap:10px; margin:0 0 4px 0">
+          <img src="/payfriends-logov2.png" alt="PayFriends Logo" style="height:36px; width:auto; vertical-align:middle" />
+          <a href="/app" style="color:var(--text); text-decoration:none; cursor:pointer">PayFriends.app</a>
+        </h1>
         <p class="user-email" id="user-email">Loading...</p>
       </div>
       <div class="header-right">
@@ -2168,8 +2178,8 @@
         const statusText = a.status || 'pending';
         const capitalizedStatus = statusText.charAt(0).toUpperCase() + statusText.slice(1);
 
-        // Build status column with main badge only
-        let statusBadge = `<span class="status-badge ${statusText}">${capitalizedStatus}</span>`;
+        // Build status column with plain colored text (no badge)
+        let statusBadge = `<span class="status-text ${statusText}">${capitalizedStatus}</span>`;
 
         // Determine role
         const isLender = a.lender_user_id === currentUser.id;

--- a/public/review-details.html
+++ b/public/review-details.html
@@ -10,7 +10,7 @@
     }
     *{box-sizing:border-box}
     body{margin:0; font-family:system-ui,-apple-system,Segoe UI,Arial,sans-serif; background:var(--bg); color:var(--text); padding:32px 16px;}
-    .container{max-width:600px; margin:0 auto;}
+    .container{max-width:1200px; margin:0 auto;}
     .card{background:var(--card); border:1px solid rgba(255,255,255,0.06); border-radius:16px; padding:24px; margin:16px 0}
     h1{margin:0 0 8px 0; font-size:24px}
     h2{margin:0 0 16px 0; font-size:20px}
@@ -34,10 +34,10 @@
     .back-link{display:inline-block; margin-bottom:16px; color:var(--accent); text-decoration:none; font-size:14px}
     .back-link:hover{text-decoration:underline}
     .status-badge{display:inline-block; padding:4px 10px; border-radius:6px; font-size:12px; font-weight:600}
-    .status-badge.pending{background:#4a4a4a; color:#fff}
-    .status-badge.active{background:#3d7bdc; color:#fff}
-    .status-badge.settled{background:#3ddc97; color:#0d130f}
-    .status-badge.declined{background:#ff6b6b; color:#fff}
+    .status-badge.pending{background:#f59e0b; color:#0d130f}
+    .status-badge.active{background:#22c55e; color:#fff}
+    .status-badge.settled{background:#9ca3af; color:#fff}
+    .status-badge.declined{background:#ef4444; color:#fff}
     .status-badge.cancelled{background:#6c757d; color:#fff}
     .alert-box{background:rgba(255,165,0,0.1); border:1px solid rgba(255,165,0,0.3); border-radius:8px; padding:12px; color:var(--text); font-size:14px; margin:16px 0}
     .form-group{margin:20px 0}


### PR DESCRIPTION
- Add PayFriends logo (payfriends-logov2.png) to dashboard header
- Replace status badges with plain colored text in agreements table (Active=green, Pending=yellow, Overdue=red, Settled=gray)
- Widen agreement detail pages from 600px to 1200px max-width
- Update status badges on detail pages to use green for Active (and improved colors for other statuses)