### PR TITLE
Fix invite text, manage header, and UI cleanup

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -148,7 +148,7 @@
           <div class="inbox-widget" onclick="toggleActivity()">
             Activity (<span class="inbox-count" id="activity-count">0</span>)
           </div>
-          <a href="/profile" style="color:var(--text); text-decoration:none; padding:8px 16px; border-radius:8px; border:1px solid rgba(255,255,255,0.15); background:transparent; font-weight:500; font-size:14px; display:inline-block">My Profile</a>
+          <a href="/profile" style="color:var(--text); text-decoration:none; padding:8px 16px; border-radius:8px; border:1px solid rgba(255,255,255,0.15); background:transparent; font-weight:500; font-size:14px; display:inline-block; white-space:nowrap">My Profile</a>
           <button class="logout-btn" onclick="logout()">Logout</button>
         </div>
       </div>

--- a/public/profile.html
+++ b/public/profile.html
@@ -51,7 +51,7 @@
         <div class="top-header-user-info" id="user-info-display">Loading...</div>
         <div class="top-header-actions">
           <a href="/app" style="color:var(--text); text-decoration:none; padding:8px 16px; border-radius:8px; border:1px solid rgba(255,255,255,0.15); background:transparent; font-weight:500; font-size:14px; display:inline-block">Activity</a>
-          <a href="/profile" style="color:var(--text); text-decoration:none; padding:8px 16px; border-radius:8px; border:1px solid rgba(255,255,255,0.15); background:transparent; font-weight:500; font-size:14px; display:inline-block">My Profile</a>
+          <a href="/profile" style="color:var(--text); text-decoration:none; padding:8px 16px; border-radius:8px; border:1px solid rgba(255,255,255,0.15); background:transparent; font-weight:500; font-size:14px; display:inline-block; white-space:nowrap">My Profile</a>
           <button class="logout-btn" onclick="logout()">Logout</button>
         </div>
       </div>

--- a/public/review-details.html
+++ b/public/review-details.html
@@ -113,7 +113,7 @@
         <div class="top-header-user-info" id="user-info-display">Loading...</div>
         <div class="top-header-actions">
           <a href="/app" style="color:var(--text); text-decoration:none; padding:8px 16px; border-radius:8px; border:1px solid rgba(255,255,255,0.15); background:transparent; font-weight:500; font-size:14px; display:inline-block">Activity</a>
-          <a href="/profile" style="color:var(--text); text-decoration:none; padding:8px 16px; border-radius:8px; border:1px solid rgba(255,255,255,0.15); background:transparent; font-weight:500; font-size:14px; display:inline-block">My Profile</a>
+          <a href="/profile" style="color:var(--text); text-decoration:none; padding:8px 16px; border-radius:8px; border:1px solid rgba(255,255,255,0.15); background:transparent; font-weight:500; font-size:14px; display:inline-block; white-space:nowrap">My Profile</a>
           <button class="logout-btn" onclick="logout()">Logout</button>
         </div>
       </div>
@@ -137,6 +137,15 @@
           <p id="agreement-summary-line2" style="margin:0; font-size:16px; line-height:1.6; color:var(--text)"></p>
         </div>
       </div>
+    </div>
+
+    <!-- Manage agreement header (for view mode) -->
+    <div id="manage-header" class="hidden" style="margin:16px 0">
+      <div style="display:flex; justify-content:space-between; align-items:flex-start; margin-bottom:8px">
+        <h2 style="margin:0; font-size:24px">Manage agreement</h2>
+        <a href="/app" style="color:var(--accent); text-decoration:none; font-size:14px; font-weight:500">← Back to list</a>
+      </div>
+      <p id="manage-subline" style="margin:8px 0 0 0; font-size:16px; color:var(--muted)"></p>
     </div>
 
     <!-- Primary payment action button (for active agreements) - moved up -->
@@ -551,6 +560,12 @@
       document.getElementById('loading-text').parentElement.classList.add('hidden');
       document.getElementById('details-section').classList.remove('hidden');
       document.getElementById('page-title').textContent = 'Agreement Details';
+
+      // Show and populate manage header
+      const borrowerName = agreement.borrower_full_name || agreement.friend_first_name || agreement.borrower_email;
+      const description = agreement.description || 'Agreement';
+      document.getElementById('manage-subline').textContent = `${description} · ${borrowerName}`;
+      document.getElementById('manage-header').classList.remove('hidden');
 
       populateDetails();
 
@@ -1757,8 +1772,9 @@
           });
 
           // Invite sent info
+          const emailPart = borrowerEmail ? ` at <strong style="color:var(--text)">${borrowerEmail}</strong>` : '';
           html += `<div>
-            <div style="color:var(--muted); font-size:14px">Invite sent to <strong style="color:var(--text)">${borrowerName}</strong> at <strong style="color:var(--text)">${borrowerEmail}</strong> on ${createdDate}.</div>
+            <div style="color:var(--muted); font-size:14px">Invite sent to <strong style="color:var(--text)">${borrowerName}</strong>${emailPart} on ${createdDate}.</div>
           </div>`;
 
           // Share link

--- a/public/review.html
+++ b/public/review.html
@@ -72,7 +72,7 @@
           <div class="top-header-user-info" id="user-info-display">Loading...</div>
           <div class="top-header-actions">
             <a href="/app" style="color:var(--text); text-decoration:none; padding:8px 16px; border-radius:8px; border:1px solid rgba(255,255,255,0.15); background:transparent; font-weight:500; font-size:14px; display:inline-block">Activity</a>
-            <a href="/profile" style="color:var(--text); text-decoration:none; padding:8px 16px; border-radius:8px; border:1px solid rgba(255,255,255,0.15); background:transparent; font-weight:500; font-size:14px; display:inline-block">My Profile</a>
+            <a href="/profile" style="color:var(--text); text-decoration:none; padding:8px 16px; border-radius:8px; border:1px solid rgba(255,255,255,0.15); background:transparent; font-weight:500; font-size:14px; display:inline-block; white-space:nowrap">My Profile</a>
             <button class="logout-btn" onclick="logout()">Logout</button>
           </div>
         </div>


### PR DESCRIPTION
This commit addresses four UX improvements:

1. Fix "Invite sent to ... at null ..." text:
   - Check if borrower email exists before displaying
   - Omit "at ..." part entirely if no email
   - Use proper name fallbacks (borrower_full_name, friend_first_name, email)

2. Add "Manage agreement" header:
   - New header section with H2 "Manage agreement"
   - Subline shows "Description · Borrower name"
   - "Back to list" link for easy navigation

3. Shared-link review page fields:
   - Verified all fields are present and working correctly
   - Description, Money transfer date, Installment plan, Interest, Total to repay
   - "Interest, payment calculation & instalment schedule" dropdown included

4. Fix "My Profile" button wrapping:
   - Add white-space:nowrap to prevent text wrapping to two lines
   - Applied consistently across all pages (app, profile, review, review-details)