### PR TITLE
Visual polish: reminders, status dots, headers, spacing

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -64,20 +64,21 @@
     .status-text.settled{color:#9ca3af}
     .status-text.cancelled{color:#9ca3af}
     .status-text.declined{color:#f87171}
-    .status-indicator{width:24px;height:24px;border-radius:9999px;display:inline-flex;align-items:center;justify-content:center;margin:0 auto;cursor:help}
+    .status-indicator{width:22px;height:22px;border-radius:9999px;display:inline-flex;align-items:center;justify-content:center;margin:0 auto;cursor:help}
     .status-indicator--active{background:#22c55e}
     .status-indicator--pending{background:#facc15}
     .status-indicator--settled{background:#9ca3af}
     .status-indicator--overdue{background:#f87171}
     .status-indicator--cancelled{background:#9ca3af}
     .status-indicator--declined{background:#f87171}
-    .status-dot{display:inline-block; width:24px; height:24px; border-radius:9999px; cursor:help; position:relative}
+    .status-dot{display:inline-block; width:22px; height:22px; border-radius:9999px; cursor:help; position:relative}
     .status-dot--active{background:#22c55e}
     .status-dot--pending{background:#facc15}
     .status-dot--settled{background:#9ca3af}
     .status-dot--overdue{background:#f87171}
     .status-dot--cancelled{background:#9ca3af}
     .status-dot--declined{background:#f87171}
+    .status-cell{display:flex;align-items:center;justify-content:center}
     .actions-column{display:flex; flex-wrap:wrap; gap:8px; align-items:center; justify-content:flex-end; width:100%}
     .actions-column button{flex:0 0 auto; padding:8px 12px; font-size:14px; white-space:nowrap; width:auto}
     .btn-confirm-payment{background:#f97316; color:#fff; border:0; padding:8px 12px; border-radius:8px; font-weight:600; cursor:pointer; font-size:14px}
@@ -146,7 +147,7 @@
     .toggle-switch input:checked + .toggle-slider{background-color:var(--accent)}
     .toggle-switch input:checked + .toggle-slider:before{transform:translateX(24px)}
     .toggle-switch input:disabled + .toggle-slider{opacity:0.5;cursor:not-allowed}
-    .reminder-option-active{border:2px solid #22c55e !important;box-shadow:0 0 0 1px rgba(34, 197, 94, 0.2)}
+    .reminder-option-active{background:rgba(61,220,151,0.05) !important;border:1px solid rgba(61,220,151,0.15) !important;border-radius:12px !important}
   </style>
 </head>
 <body>
@@ -2728,11 +2729,15 @@
         // Build status column with colored dot indicator (no text)
         let tooltipText = capitalizedStatus;
         if (statusText === 'pending') {
-          tooltipText = 'Pending review by borrower';
+          tooltipText = 'Pending';
         } else if (statusText === 'active') {
           tooltipText = 'Active';
         } else if (statusText === 'settled') {
           tooltipText = 'Settled';
+        } else if (statusText === 'cancelled') {
+          tooltipText = 'Cancelled';
+        } else if (statusText === 'declined') {
+          tooltipText = 'Declined';
         }
         let statusBadge = `<span class="status-dot status-dot--${statusText}" role="img" aria-label="${capitalizedStatus}" title="${tooltipText}"></span>`;
 
@@ -2793,7 +2798,7 @@
           <td>${description}</td>
           <td>${outstandingDisplay}</td>
           <td>${dueDateDisplay}</td>
-          <td>${statusBadge}</td>
+          <td class="status-cell">${statusBadge}</td>
           <td>${actionsHtml}</td>
         `;
         tbody.appendChild(tr);

--- a/public/profile.html
+++ b/public/profile.html
@@ -56,7 +56,7 @@
     .user-avatar-initials.color-7{background:#14b8a6;color:#fff}
 
     /* Profile header with avatar */
-    .profile-header{display:flex;flex-direction:column;align-items:center;gap:12px;margin-top:24px;margin-bottom:24px}
+    .profile-header{display:flex;flex-direction:column;align-items:center;gap:12px;margin-top:24px;margin-bottom:12px}
     .profile-info{display:flex;flex-direction:column;gap:6px}
     .profile-name{font-size:20px;font-weight:600;color:var(--text)}
     .profile-detail{font-size:14px;color:var(--muted)}

--- a/public/review-details.html
+++ b/public/review-details.html
@@ -112,6 +112,7 @@
     .user-avatar.size-small{width:22px; height:22px; font-size:10px; font-weight:600; margin-right:8px}
     .user-avatar.size-medium{width:48px; height:48px; font-size:18px; font-weight:600}
     .user-avatar.size-large{width:60px; height:60px; font-size:22px; font-weight:600; margin-right:16px}
+    .user-avatar.size-xl{width:110px; height:110px; font-size:36px; font-weight:600; margin-right:20px}
     .user-avatar-image{width:100%; height:100%; object-fit:cover}
     .user-avatar-initials{width:100%; height:100%; display:flex; align-items:center; justify-content:center; color:#fff; font-weight:600; text-transform:uppercase}
     .user-avatar-initials.color-1{background:#6366f1}
@@ -125,20 +126,21 @@
     .due-date-overdue{color:#f87171}
     .due-date-upcoming{color:var(--muted)}
     .due-date-settled{color:#9ca3af}
-    .status-indicator{width:24px;height:24px;border-radius:9999px;display:inline-flex;align-items:center;justify-content:center;margin:0 auto;cursor:help}
+    .status-indicator{width:22px;height:22px;border-radius:9999px;display:inline-flex;align-items:center;justify-content:center;margin:0 auto;cursor:help}
     .status-indicator--active{background:#22c55e}
     .status-indicator--pending{background:#facc15}
     .status-indicator--settled{background:#9ca3af}
     .status-indicator--overdue{background:#f87171}
     .status-indicator--cancelled{background:#9ca3af}
     .status-indicator--declined{background:#f87171}
-    .status-dot{display:inline-block; width:24px; height:24px; border-radius:9999px; cursor:help; position:relative}
+    .status-dot{display:inline-block; width:22px; height:22px; border-radius:9999px; cursor:help; position:relative}
     .status-dot--active{background:#22c55e}
     .status-dot--pending{background:#facc15}
     .status-dot--settled{background:#9ca3af}
     .status-dot--overdue{background:#f87171}
     .status-dot--cancelled{background:#9ca3af}
     .status-dot--declined{background:#f87171}
+    .status-cell{display:flex;align-items:center;justify-content:center}
   </style>
 </head>
 <body>
@@ -191,6 +193,12 @@
       </table>
       <div id="empty-state" class="empty-state" style="display:none">
         No agreements found for this filter.
+      </div>
+      <div style="display:flex; justify-content:flex-end; margin-top:16px">
+        <button onclick="window.location.href='/app'" style="display:flex; align-items:center; gap:8px; padding:12px 20px; width:auto">
+          <span style="font-size:18px; font-weight:bold">+</span>
+          <span>New Agreement</span>
+        </button>
       </div>
     </section>
 
@@ -760,11 +768,11 @@
       // Create and insert borrower avatar (always show borrower)
       let avatarHtml = '';
       if (agreement.borrower_profile_picture && agreement.borrower_user_id) {
-        avatarHtml = `<div class="user-avatar size-large"><img src="/api/profile/picture/${agreement.borrower_user_id}" class="user-avatar-image" /></div>`;
+        avatarHtml = `<div class="user-avatar size-xl"><img src="/api/profile/picture/${agreement.borrower_user_id}" class="user-avatar-image" /></div>`;
       } else {
         const initials = getInitials(borrowerName);
         const colorClass = getAvatarColor(borrowerName);
-        avatarHtml = `<div class="user-avatar size-large"><div class="user-avatar-initials ${colorClass}">${initials}</div></div>`;
+        avatarHtml = `<div class="user-avatar size-xl"><div class="user-avatar-initials ${colorClass}">${initials}</div></div>`;
       }
       document.getElementById('summary-avatar').innerHTML = avatarHtml;
 
@@ -2066,11 +2074,15 @@
         const capitalizedStatus = statusText.charAt(0).toUpperCase() + statusText.slice(1);
         let tooltipText = capitalizedStatus;
         if (statusText === 'pending') {
-          tooltipText = 'Pending review by borrower';
+          tooltipText = 'Pending';
         } else if (statusText === 'active') {
           tooltipText = 'Active';
         } else if (statusText === 'settled') {
           tooltipText = 'Settled';
+        } else if (statusText === 'cancelled') {
+          tooltipText = 'Cancelled';
+        } else if (statusText === 'declined') {
+          tooltipText = 'Declined';
         }
         let statusHtml = `<span class="status-dot status-dot--${statusText}" role="img" aria-label="${capitalizedStatus}" title="${tooltipText}"></span>`;
 
@@ -2093,7 +2105,7 @@
           <td>${description}</td>
           <td title="Original amount: € ${originalAmount}">€ ${outstanding} / € ${originalAmount}</td>
           <td class="${dueDateClass}">${dueDate}</td>
-          <td>${statusHtml}</td>
+          <td class="status-cell">${statusHtml}</td>
           <td>
             <div class="actions-column">
               ${actionsHtml}


### PR DESCRIPTION
This commit implements a series of focused UI polish improvements:

1. Reminders card highlight (Step 4)
   - Match selected reminder option style to green summary box
   - Background: rgba(61,220,151,0.05), Border: 1px solid rgba(61,220,151,0.15)
   - Consistent with Step 5 summary and Manage page summary styling

2. Status dot improvements (My Agreements tables)
   - Reduce size from 24px to 22px to match avatar circle size
   - Apply flexbox centering (.status-cell) for perfect vertical alignment
   - Fix tooltips: "Pending" (not "Pending review by borrower"), "Active", "Settled", etc.
   - Applied to both Dashboard and Manage page tables

3. Manage page summary avatar
   - Increase from 60px to 110px (.size-xl) for better visual balance
   - Avatar now roughly matches height of three-line text summary

4. Header consistency & Activity count
   - All pages (Dashboard, Manage, Profile) already had consistent headers
   - Activity count loading already implemented across all pages
   - No changes needed (verified consistency)

5. Container width
   - Already consistent: max-width 1200px across all pages
   - No changes needed (verified alignment)

6. Manage page My Agreements
   - Add "+ New Agreement" button (same position/style as Dashboard)
   - Redirects to /app to open New Agreement flow

7. Profile page spacing
   - Reduce margin-bottom on .profile-header from 24px to 12px
   - Tighter spacing below "Change photo" for more compact layout

All changes maintain existing functionality and behavior.