### PR TITLE
Fix broken row divider in Status column of My Agreements table

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -78,7 +78,7 @@
     .status-dot--overdue{background:#f87171}
     .status-dot--cancelled{background:#9ca3af}
     .status-dot--declined{background:#f87171}
-    .status-cell{display:flex;align-items:center;justify-content:center}
+    .status-dot-wrapper{display:flex;align-items:center;justify-content:center;height:100%}
     .actions-column{display:flex; flex-wrap:wrap; gap:8px; align-items:center; justify-content:flex-end; width:100%}
     .actions-column button{flex:0 0 auto; padding:8px 12px; font-size:14px; white-space:nowrap; width:auto}
     .btn-confirm-payment{background:#f97316; color:#fff; border:0; padding:8px 12px; border-radius:8px; font-weight:600; cursor:pointer; font-size:14px}
@@ -2903,7 +2903,7 @@
         } else if (statusText === 'declined') {
           tooltipText = 'Declined';
         }
-        let statusBadge = `<span class="status-dot status-dot--${statusText}" role="img" aria-label="${capitalizedStatus}" title="${tooltipText}"></span>`;
+        let statusBadge = `<div class="status-dot-wrapper"><span class="status-dot status-dot--${statusText}" role="img" aria-label="${capitalizedStatus}" title="${tooltipText}"></span></div>`;
 
         // Determine role
         const isLender = a.lender_user_id === currentUser.id;
@@ -2962,7 +2962,7 @@
           <td>${description}</td>
           <td>${outstandingDisplay}</td>
           <td>${dueDateDisplay}</td>
-          <td class="status-cell">${statusBadge}</td>
+          <td>${statusBadge}</td>
           <td>${actionsHtml}</td>
         `;
         tbody.appendChild(tr);

--- a/public/review-details.html
+++ b/public/review-details.html
@@ -140,7 +140,7 @@
     .status-dot--overdue{background:#f87171}
     .status-dot--cancelled{background:#9ca3af}
     .status-dot--declined{background:#f87171}
-    .status-cell{display:flex;align-items:center;justify-content:center}
+    .status-dot-wrapper{display:flex;align-items:center;justify-content:center;height:100%}
   </style>
 </head>
 <body>
@@ -2084,7 +2084,7 @@
         } else if (statusText === 'declined') {
           tooltipText = 'Declined';
         }
-        let statusHtml = `<span class="status-dot status-dot--${statusText}" role="img" aria-label="${capitalizedStatus}" title="${tooltipText}"></span>`;
+        let statusHtml = `<div class="status-dot-wrapper"><span class="status-dot status-dot--${statusText}" role="img" aria-label="${capitalizedStatus}" title="${tooltipText}"></span></div>`;
 
         // Actions
         let actionsHtml = '';
@@ -2105,7 +2105,7 @@
           <td>${description}</td>
           <td title="Original amount: € ${originalAmount}">€ ${outstanding} / € ${originalAmount}</td>
           <td class="${dueDateClass}">${dueDate}</td>
-          <td class="status-cell">${statusHtml}</td>
+          <td>${statusHtml}</td>
           <td>
             <div class="actions-column">
               ${actionsHtml}


### PR DESCRIPTION
The Status column's table cell had display:flex applied directly to the td, which was breaking the horizontal row divider line. The line would stop under the Outstanding/Total column and resume under Actions, creating a visual gap.

Changes:
- Removed display:flex from .status-cell CSS class
- Created new .status-dot-wrapper class with flex centering properties
- Wrapped status dot span in the wrapper div inside each td
- Removed status-cell class from td elements (no longer needed)

The td now behaves as a normal table cell with a continuous border-bottom, while the inner wrapper div handles the flexbox centering of the status dot.

Applied consistently to both:
- Dashboard page (app.html)
- Manage page (review-details.html)