### PR TITLE
Replace phone widget with custom component

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -4,12 +4,11 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>PayFriends — My Agreements</title>
-  <!-- intl-tel-input library -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/intl-tel-input@23.0.4/build/css/intlTelInput.min.css">
-  <script src="https://cdn.jsdelivr.net/npm/intl-tel-input@23.0.4/build/js/intlTelInput.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/qrcodejs@1.0.0/qrcode.min.js"></script>
   <!-- Shared header component -->
   <script src="/js/header.js"></script>
+  <!-- Phone input component -->
+  <script src="/js/phone-input.js"></script>
   <style>
     :root{
       --bg:#0e1116; --card:#151a21; --text:#e6eef6; --muted:#a7b0bd; --accent:#3ddc97;
@@ -154,108 +153,131 @@
     .toggle-switch input:disabled + .toggle-slider{opacity:0.5;cursor:not-allowed}
     .reminder-option-active{background:rgba(61,220,151,0.05) !important;border:1px solid rgba(61,220,151,0.15) !important;border-radius:12px !important}
 
-    /* intl-tel-input custom dark theme styling - scoped with .pf-phone-input wrapper */
-    .pf-phone-input .iti{width:100%}
+    /* Custom Phone Input Widget */
+    .phone-input-wrapper{position:relative}
+    .phone-input-row{display:flex;gap:8px;align-items:stretch}
 
-    /* Input field */
-    .pf-phone-input .iti__input{
-      width:100%;
-      padding:10px 12px 10px 52px;
-      border-radius:10px;
-      border:1px solid rgba(255,255,255,0.08);
+    /* Country button */
+    .phone-country-button{
+      display:flex;align-items:center;gap:8px;
+      padding:0 12px;
       background:#10151d;
+      border:1px solid rgba(255,255,255,0.12);
+      border-radius:10px;
       color:var(--text);
-      font-family:system-ui, -apple-system, sans-serif;
       font-size:15px;
+      cursor:pointer;
+      transition:all 0.2s;
+      white-space:nowrap;
+      min-width:180px;
+    }
+    .phone-country-button:hover,
+    .phone-country-button:focus{
+      border-color:rgba(61,220,151,0.4);
+      outline:none;
+    }
+    .phone-country-flag{font-size:18px}
+    .phone-country-name{flex:1}
+    .phone-caret{font-size:10px;color:var(--muted)}
+
+    /* Prefix display */
+    .phone-prefix{
+      display:flex;align-items:center;
+      padding:0 12px;
+      background:#10151d;
+      border:1px solid rgba(255,255,255,0.12);
+      border-radius:10px;
+      color:var(--muted);
+      font-size:15px;
+      min-width:60px;
+      justify-content:center;
     }
 
-    /* Flag container */
-    .pf-phone-input .iti__flag-container{
-      background:#111;
-      border-right:1px solid rgba(255,255,255,0.06);
-      border-radius:10px 0 0 10px;
+    /* Local number input */
+    .phone-number-input{
+      flex:1;
+      padding:12px;
+      background:#10151d;
+      border:1px solid rgba(255,255,255,0.12);
+      border-radius:10px;
+      color:var(--text);
+      font-size:15px;
+      font-family:system-ui,-apple-system,Segoe UI,Arial,sans-serif;
     }
-    .pf-phone-input .iti__selected-flag{
-      padding:0 10px;
-      background:transparent;
-    }
-
-    /* Dropdown container */
-    .pf-phone-input .iti__dropdown,
-    .pf-phone-input .iti__country-list{
-      background-color:#1a1a1a !important;
-      border:1px solid rgba(255,255,255,0.15) !important;
-      color:#f3f3f3 !important;
-      box-shadow:0 4px 16px rgba(0, 0, 0, 0.4);
-      border-radius:8px !important;
-      width:100%;
-      max-height:260px;
-      padding-top:4px;
-      padding-bottom:4px;
-      overflow-y:auto;
-      z-index:1000;
-      margin-top:4px;
-    }
-
-    /* Search input */
-    .pf-phone-input .iti__search-input{
-      background-color:#111 !important;
-      color:#f3f3f3 !important;
-      border:1px solid rgba(255,255,255,0.1) !important;
-      border-radius:8px !important;
-      padding:10px 12px !important;
-      font-size:15px !important;
-      font-family:system-ui, sans-serif !important;
-      margin:6px 10px 8px;
-      width:calc(100% - 20px);
-    }
-    .pf-phone-input .iti__search-input::placeholder{
-      color:rgba(255,255,255,0.5) !important;
-    }
-    .pf-phone-input .iti__search-input:focus{
+    .phone-number-input:focus{
       outline:none;
       border-color:rgba(61,220,151,0.4);
     }
+    .phone-number-input.phone-input-invalid{
+      border-color:#ff6b6b;
+    }
 
-    /* Country rows */
-    .pf-phone-input .iti__country{
-      padding:7px 12px;
+    /* Hidden full number field */
+    .phone-number-full{display:none}
+
+    /* Dropdown */
+    .phone-dropdown{
+      display:none;
+      position:absolute;
+      top:100%;
+      left:0;
+      right:0;
+      margin-top:4px;
+      background:#151a21;
+      border:1px solid rgba(255,255,255,0.15);
+      border-radius:10px;
+      box-shadow:0 4px 16px rgba(0,0,0,0.4);
+      z-index:1000;
+      max-height:320px;
+      overflow:hidden;
+    }
+
+    /* Dropdown search */
+    .phone-dropdown-search{
+      width:calc(100% - 24px);
+      margin:12px;
+      padding:10px 12px;
+      background:#10151d;
+      border:1px solid rgba(255,255,255,0.12);
+      border-radius:8px;
+      color:var(--text);
+      font-size:15px;
+      font-family:system-ui,-apple-system,Segoe UI,Arial,sans-serif;
+    }
+    .phone-dropdown-search:focus{
+      outline:none;
+      border-color:rgba(61,220,151,0.4);
+    }
+    .phone-dropdown-search::placeholder{
+      color:var(--muted);
+    }
+
+    /* Country list */
+    .phone-country-list{
+      max-height:220px;
+      overflow-y:auto;
+      padding:4px 0;
+    }
+    .phone-country-list::-webkit-scrollbar{width:6px}
+    .phone-country-list::-webkit-scrollbar-thumb{background-color:#333;border-radius:4px}
+
+    /* Country item */
+    .phone-country-item{
       display:flex;
       align-items:center;
-      gap:8px;
-      font-size:14px;
-      color:#f3f3f3;
-      border-left:3px solid transparent;
-      transition:all 0.1s ease;
-    }
-
-    /* Hover and keyboard focus (highlight) */
-    .pf-phone-input .iti__country.iti__highlight{
-      background-color:rgba(61,220,151,0.08) !important;
-      border-left:3px solid #3ddc97 !important;
+      gap:10px;
+      padding:10px 16px;
       cursor:pointer;
+      transition:all 0.15s;
+      border-left:3px solid transparent;
     }
-
-    /* Currently selected/active entry */
-    .pf-phone-input .iti__country.iti__active{
-      background:rgba(61,220,151,0.06);
+    .phone-country-item:hover{
+      background:rgba(61,220,151,0.08);
+      border-left-color:var(--accent);
     }
-
-    /* Text colors */
-    .pf-phone-input .iti__dial-code{color:rgba(255,255,255,0.6)}
-    .pf-phone-input .iti__country-name{color:#f3f3f3}
-
-    /* Divider */
-    .pf-phone-input .iti__divider{border-bottom:1px solid rgba(255,255,255,0.08)}
-
-    /* Custom scrollbar */
-    .pf-phone-input .iti__country-list::-webkit-scrollbar{
-      width:6px;
-    }
-    .pf-phone-input .iti__country-list::-webkit-scrollbar-thumb{
-      background-color:#333;
-      border-radius:4px;
-    }
+    .phone-country-item .phone-country-flag{font-size:18px}
+    .phone-country-item .phone-country-name{flex:1;color:var(--text);font-size:14px}
+    .phone-country-item .phone-country-dial{color:var(--muted);font-size:14px}
 
     /* Phone error message */
     .phone-error{color:#ff6b6b;font-size:13px;margin-top:4px;display:none}
@@ -393,9 +415,20 @@
           </div>
           <p style="color:var(--muted); font-size:12px; margin:-6px 0 12px 172px">They'll receive a link to review the agreement.</p>
 
-          <div class="row pf-phone-input">
+          <div class="row">
             <label>Phone number*</label>
-            <input id="agreement-phone" type="tel" required />
+            <div class="phone-input-wrapper" data-phone-id="agreement-phone">
+              <div class="phone-input-row">
+                <button type="button" class="phone-country-button"></button>
+                <span class="phone-prefix"></span>
+                <input type="tel" class="phone-number-input" placeholder="612345678" />
+                <input type="hidden" id="agreement-phone" name="agreement-phone" class="phone-number-full" />
+              </div>
+              <div class="phone-dropdown">
+                <input type="text" class="phone-dropdown-search" placeholder="Search country or code…" />
+                <div class="phone-country-list"></div>
+              </div>
+            </div>
             <div id="agreement-phone-error" class="phone-error">Please enter a valid phone number.</div>
           </div>
           <p style="color:rgba(255,255,255,0.5); font-size:13px; margin:-6px 0 12px 172px">Your phone number is required to send reminder messages.</p>
@@ -1307,12 +1340,17 @@
         return false;
       }
 
-      // Validate phone number using intl-tel-input
-      if (!agreementPhoneInput.isValidNumber()) {
+      // Validate phone number
+      if (!agreementPhoneInput || !agreementPhoneInput.isValidNumber()) {
         phoneError.style.display = 'block';
+        if (agreementPhoneInput) {
+          agreementPhoneInput.setInvalid(true);
+        }
         status.textContent = 'Please fix the errors above';
         return false;
       }
+      // Clear invalid state if valid
+      agreementPhoneInput.setInvalid(false);
 
       if (!description) {
         status.textContent = 'Please enter loan description';
@@ -3418,21 +3456,9 @@
         onActivityClick: toggleActivity
       });
 
-      // Initialize phone input
-      const phoneInput = document.querySelector("#agreement-phone");
-      agreementPhoneInput = window.intlTelInput(phoneInput, {
-        initialCountry: "auto",
-        geoIpLookup: callback => {
-          fetch('https://ipapi.co/json')
-            .then(res => res.json())
-            .then(data => callback(data.country_code))
-            .catch(() => callback('es'));
-        },
-        nationalMode: false,
-        formatOnDisplay: true,
-        separateDialCode: false,
-        utilsScript: "https://cdn.jsdelivr.net/npm/intl-tel-input@23.0.4/build/js/utils.js"
-      });
+      // Phone input is auto-initialized by PhoneInputManager
+      // Get reference to the instance
+      agreementPhoneInput = window.PhoneInputManager.getInstance('agreement-phone');
 
       // Load user and other data
       loadUser();

--- a/public/js/phone-input.js
+++ b/public/js/phone-input.js
@@ -1,0 +1,283 @@
+/**
+ * PayFriends Custom Phone Input Component
+ * A clean, dark-themed phone number input with country selection
+ */
+
+const COUNTRIES = [
+  { name: 'Netherlands', code: 'NL', dialCode: '+31', flag: '🇳🇱' },
+  { name: 'Spain', code: 'ES', dialCode: '+34', flag: '🇪🇸' },
+  { name: 'France', code: 'FR', dialCode: '+33', flag: '🇫🇷' },
+  { name: 'Germany', code: 'DE', dialCode: '+49', flag: '🇩🇪' },
+  { name: 'United Kingdom', code: 'GB', dialCode: '+44', flag: '🇬🇧' },
+  { name: 'Belgium', code: 'BE', dialCode: '+32', flag: '🇧🇪' },
+  { name: 'Italy', code: 'IT', dialCode: '+39', flag: '🇮🇹' },
+  { name: 'Portugal', code: 'PT', dialCode: '+351', flag: '🇵🇹' },
+  { name: 'United States', code: 'US', dialCode: '+1', flag: '🇺🇸' },
+  { name: 'Poland', code: 'PL', dialCode: '+48', flag: '🇵🇱' },
+  { name: 'Sweden', code: 'SE', dialCode: '+46', flag: '🇸🇪' },
+  { name: 'Norway', code: 'NO', dialCode: '+47', flag: '🇳🇴' },
+  { name: 'Denmark', code: 'DK', dialCode: '+45', flag: '🇩🇰' },
+  { name: 'Austria', code: 'AT', dialCode: '+43', flag: '🇦🇹' },
+  { name: 'Switzerland', code: 'CH', dialCode: '+41', flag: '🇨🇭' },
+];
+
+class PhoneInput {
+  constructor(container) {
+    this.container = container;
+    this.selectedCountry = COUNTRIES[0]; // Default to Netherlands
+    this.elements = {};
+    this.isDropdownOpen = false;
+
+    this.init();
+  }
+
+  init() {
+    // Find or create elements
+    this.elements.countryButton = this.container.querySelector('.phone-country-button');
+    this.elements.prefix = this.container.querySelector('.phone-prefix');
+    this.elements.localInput = this.container.querySelector('.phone-number-input');
+    this.elements.fullInput = this.container.querySelector('.phone-number-full');
+    this.elements.dropdown = this.container.querySelector('.phone-dropdown');
+    this.elements.searchInput = this.container.querySelector('.phone-dropdown-search');
+    this.elements.countryList = this.container.querySelector('.phone-country-list');
+
+    // Set up event listeners
+    this.setupEventListeners();
+
+    // Initialize with default country
+    this.updateCountryDisplay();
+
+    // Parse existing value if present
+    const initialValue = this.elements.fullInput.value;
+    if (initialValue) {
+      this.setNumber(initialValue);
+    }
+  }
+
+  setupEventListeners() {
+    // Country button click - toggle dropdown
+    this.elements.countryButton.addEventListener('click', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      this.toggleDropdown();
+    });
+
+    // Search input
+    this.elements.searchInput.addEventListener('input', (e) => {
+      this.filterCountries(e.target.value);
+    });
+
+    // Local number input
+    this.elements.localInput.addEventListener('input', (e) => {
+      this.handleLocalInput(e);
+    });
+
+    // Close dropdown when clicking outside
+    document.addEventListener('click', (e) => {
+      if (!this.container.contains(e.target) && this.isDropdownOpen) {
+        this.closeDropdown();
+      }
+    });
+
+    // Close dropdown on Escape key
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && this.isDropdownOpen) {
+        this.closeDropdown();
+      }
+    });
+
+    // Render country list
+    this.renderCountryList();
+  }
+
+  toggleDropdown() {
+    if (this.isDropdownOpen) {
+      this.closeDropdown();
+    } else {
+      this.openDropdown();
+    }
+  }
+
+  openDropdown() {
+    this.isDropdownOpen = true;
+    this.elements.dropdown.style.display = 'block';
+    this.elements.searchInput.value = '';
+    this.elements.searchInput.focus();
+    this.filterCountries('');
+  }
+
+  closeDropdown() {
+    this.isDropdownOpen = false;
+    this.elements.dropdown.style.display = 'none';
+  }
+
+  filterCountries(query) {
+    const lowerQuery = query.toLowerCase();
+    const filteredCountries = COUNTRIES.filter(country => {
+      return country.name.toLowerCase().includes(lowerQuery) ||
+             country.code.toLowerCase().includes(lowerQuery) ||
+             country.dialCode.includes(lowerQuery);
+    });
+
+    this.renderCountryList(filteredCountries);
+  }
+
+  renderCountryList(countries = COUNTRIES) {
+    this.elements.countryList.innerHTML = countries.map(country => `
+      <div class="phone-country-item" data-code="${country.code}">
+        <span class="phone-country-flag">${country.flag}</span>
+        <span class="phone-country-name">${country.name}</span>
+        <span class="phone-country-dial">${country.dialCode}</span>
+      </div>
+    `).join('');
+
+    // Add click listeners to country items
+    this.elements.countryList.querySelectorAll('.phone-country-item').forEach(item => {
+      item.addEventListener('click', () => {
+        const countryCode = item.dataset.code;
+        const country = COUNTRIES.find(c => c.code === countryCode);
+        if (country) {
+          this.selectCountry(country);
+          this.closeDropdown();
+          this.elements.localInput.focus();
+        }
+      });
+    });
+  }
+
+  selectCountry(country) {
+    this.selectedCountry = country;
+    this.updateCountryDisplay();
+    this.updateFullNumber();
+  }
+
+  updateCountryDisplay() {
+    // Update button content
+    this.elements.countryButton.innerHTML = `
+      <span class="phone-country-flag">${this.selectedCountry.flag}</span>
+      <span class="phone-country-name">${this.selectedCountry.name}</span>
+      <span class="phone-caret">▼</span>
+    `;
+
+    // Update prefix
+    this.elements.prefix.textContent = this.selectedCountry.dialCode;
+  }
+
+  handleLocalInput(e) {
+    let value = e.target.value;
+
+    // If user types a +, try to detect country
+    if (value.startsWith('+')) {
+      this.detectAndSetCountry(value);
+      return;
+    }
+
+    // Strip non-digits from local input
+    const digitsOnly = value.replace(/\D/g, '');
+    e.target.value = digitsOnly;
+
+    this.updateFullNumber();
+  }
+
+  detectAndSetCountry(fullNumber) {
+    // Try to match the dial code
+    const sortedCountries = [...COUNTRIES].sort((a, b) => b.dialCode.length - a.dialCode.length);
+
+    for (const country of sortedCountries) {
+      if (fullNumber.startsWith(country.dialCode)) {
+        this.selectedCountry = country;
+        this.updateCountryDisplay();
+
+        // Extract local part
+        const localPart = fullNumber.substring(country.dialCode.length).replace(/\D/g, '');
+        this.elements.localInput.value = localPart;
+        this.updateFullNumber();
+        return;
+      }
+    }
+
+    // If no match, just strip non-digits
+    const digitsOnly = fullNumber.replace(/\D/g, '');
+    this.elements.localInput.value = digitsOnly;
+    this.updateFullNumber();
+  }
+
+  updateFullNumber() {
+    const localDigits = this.elements.localInput.value.replace(/\D/g, '');
+    const fullNumber = localDigits ? `${this.selectedCountry.dialCode}${localDigits}` : '';
+    this.elements.fullInput.value = fullNumber;
+  }
+
+  // Public API methods
+  setNumber(e164Number) {
+    if (!e164Number || !e164Number.startsWith('+')) {
+      return;
+    }
+
+    // Try to detect country from dial code
+    const sortedCountries = [...COUNTRIES].sort((a, b) => b.dialCode.length - a.dialCode.length);
+
+    for (const country of sortedCountries) {
+      if (e164Number.startsWith(country.dialCode)) {
+        this.selectedCountry = country;
+        this.updateCountryDisplay();
+
+        // Extract local part
+        const localPart = e164Number.substring(country.dialCode.length).replace(/\D/g, '');
+        this.elements.localInput.value = localPart;
+        this.updateFullNumber();
+        return;
+      }
+    }
+  }
+
+  getNumber() {
+    return this.elements.fullInput.value;
+  }
+
+  isValidNumber() {
+    const number = this.getNumber();
+    // Basic validation: must have a dial code and at least one digit
+    return number.startsWith('+') && number.length > this.selectedCountry.dialCode.length;
+  }
+
+  setInvalid(invalid) {
+    if (invalid) {
+      this.elements.localInput.classList.add('phone-input-invalid');
+    } else {
+      this.elements.localInput.classList.remove('phone-input-invalid');
+    }
+  }
+}
+
+// Auto-initialize all phone inputs on the page
+const PhoneInputManager = {
+  instances: new Map(),
+
+  initialize() {
+    document.querySelectorAll('.phone-input-wrapper').forEach(container => {
+      const id = container.dataset.phoneId || container.querySelector('.phone-number-full')?.id;
+      if (id && !this.instances.has(id)) {
+        const instance = new PhoneInput(container);
+        this.instances.set(id, instance);
+      }
+    });
+  },
+
+  getInstance(id) {
+    return this.instances.get(id);
+  }
+};
+
+// Auto-initialize on DOM ready
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', () => {
+    PhoneInputManager.initialize();
+  });
+} else {
+  PhoneInputManager.initialize();
+}
+
+// Export for use in other scripts
+window.PhoneInputManager = PhoneInputManager;
+window.PhoneInput = PhoneInput;

--- a/public/profile.html
+++ b/public/profile.html
@@ -4,11 +4,10 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>PayFriends — My Profile</title>
-  <!-- intl-tel-input library -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/intl-tel-input@23.0.4/build/css/intlTelInput.min.css">
-  <script src="https://cdn.jsdelivr.net/npm/intl-tel-input@23.0.4/build/js/intlTelInput.min.js"></script>
   <!-- Shared header component -->
   <script src="/js/header.js"></script>
+  <!-- Phone input component -->
+  <script src="/js/phone-input.js"></script>
   <style>
     :root{
       --bg:#0e1116; --card:#151a21; --text:#e6eef6; --muted:#a7b0bd; --accent:#3ddc97;
@@ -60,108 +59,131 @@
     .user-avatar-initials.color-6{background:#8b5cf6;color:#fff}
     .user-avatar-initials.color-7{background:#14b8a6;color:#fff}
 
-    /* intl-tel-input custom dark theme styling - scoped with .pf-phone-input wrapper */
-    .pf-phone-input .iti{width:100%}
+    /* Custom Phone Input Widget */
+    .phone-input-wrapper{position:relative}
+    .phone-input-row{display:flex;gap:8px;align-items:stretch}
 
-    /* Input field */
-    .pf-phone-input .iti__input{
-      width:100%;
-      padding:12px 12px 12px 52px;
-      border-radius:10px;
-      border:1px solid rgba(255,255,255,0.08);
+    /* Country button */
+    .phone-country-button{
+      display:flex;align-items:center;gap:8px;
+      padding:0 12px;
       background:#10151d;
+      border:1px solid rgba(255,255,255,0.12);
+      border-radius:10px;
       color:var(--text);
-      font-family:"Inter", system-ui, -apple-system, sans-serif;
       font-size:15px;
+      cursor:pointer;
+      transition:all 0.2s;
+      white-space:nowrap;
+      min-width:180px;
+    }
+    .phone-country-button:hover,
+    .phone-country-button:focus{
+      border-color:rgba(61,220,151,0.4);
+      outline:none;
+    }
+    .phone-country-flag{font-size:18px}
+    .phone-country-name{flex:1}
+    .phone-caret{font-size:10px;color:var(--muted)}
+
+    /* Prefix display */
+    .phone-prefix{
+      display:flex;align-items:center;
+      padding:0 12px;
+      background:#10151d;
+      border:1px solid rgba(255,255,255,0.12);
+      border-radius:10px;
+      color:var(--muted);
+      font-size:15px;
+      min-width:60px;
+      justify-content:center;
     }
 
-    /* Flag container */
-    .pf-phone-input .iti__flag-container{
-      background:#111;
-      border-right:1px solid rgba(255,255,255,0.06);
-      border-radius:10px 0 0 10px;
+    /* Local number input */
+    .phone-number-input{
+      flex:1;
+      padding:12px;
+      background:#10151d;
+      border:1px solid rgba(255,255,255,0.12);
+      border-radius:10px;
+      color:var(--text);
+      font-size:15px;
+      font-family:system-ui,-apple-system,Segoe UI,Arial,sans-serif;
     }
-    .pf-phone-input .iti__selected-flag{
-      padding:0 10px;
-      background:transparent;
-    }
-
-    /* Dropdown container */
-    .pf-phone-input .iti__dropdown,
-    .pf-phone-input .iti__country-list{
-      background-color:#111 !important;
-      border:1px solid rgba(255,255,255,0.1) !important;
-      color:#f3f3f3 !important;
-      box-shadow:0 4px 16px rgba(0, 0, 0, 0.6);
-      border-radius:8px !important;
-      width:100%;
-      max-height:260px;
-      padding-top:4px;
-      padding-bottom:4px;
-      overflow-y:auto;
-      z-index:1000;
-      margin-top:4px;
-    }
-
-    /* Search input */
-    .pf-phone-input .iti__search-input{
-      background-color:#1a1a1a !important;
-      color:#fff !important;
-      border:1px solid rgba(255,255,255,0.15) !important;
-      border-radius:6px !important;
-      padding:8px 12px !important;
-      font-size:15px !important;
-      font-family:Inter, sans-serif !important;
-      margin:6px 10px 8px;
-      width:calc(100% - 20px);
-    }
-    .pf-phone-input .iti__search-input::placeholder{
-      color:rgba(255,255,255,0.5) !important;
-    }
-    .pf-phone-input .iti__search-input:focus{
+    .phone-number-input:focus{
       outline:none;
       border-color:rgba(61,220,151,0.4);
     }
+    .phone-number-input.phone-input-invalid{
+      border-color:#ff6b6b;
+    }
 
-    /* Country rows */
-    .pf-phone-input .iti__country{
-      padding:7px 12px;
+    /* Hidden full number field */
+    .phone-number-full{display:none}
+
+    /* Dropdown */
+    .phone-dropdown{
+      display:none;
+      position:absolute;
+      top:100%;
+      left:0;
+      right:0;
+      margin-top:4px;
+      background:#151a21;
+      border:1px solid rgba(255,255,255,0.15);
+      border-radius:10px;
+      box-shadow:0 4px 16px rgba(0,0,0,0.4);
+      z-index:1000;
+      max-height:320px;
+      overflow:hidden;
+    }
+
+    /* Dropdown search */
+    .phone-dropdown-search{
+      width:calc(100% - 24px);
+      margin:12px;
+      padding:10px 12px;
+      background:#10151d;
+      border:1px solid rgba(255,255,255,0.12);
+      border-radius:8px;
+      color:var(--text);
+      font-size:15px;
+      font-family:system-ui,-apple-system,Segoe UI,Arial,sans-serif;
+    }
+    .phone-dropdown-search:focus{
+      outline:none;
+      border-color:rgba(61,220,151,0.4);
+    }
+    .phone-dropdown-search::placeholder{
+      color:var(--muted);
+    }
+
+    /* Country list */
+    .phone-country-list{
+      max-height:220px;
+      overflow-y:auto;
+      padding:4px 0;
+    }
+    .phone-country-list::-webkit-scrollbar{width:6px}
+    .phone-country-list::-webkit-scrollbar-thumb{background-color:#333;border-radius:4px}
+
+    /* Country item */
+    .phone-country-item{
       display:flex;
       align-items:center;
-      gap:8px;
-      font-size:14px;
-      color:#f3f3f3;
-      border-left:3px solid transparent;
-      transition:all 0.1s ease;
-    }
-
-    /* Hover and keyboard focus (highlight) */
-    .pf-phone-input .iti__country.iti__highlight{
-      background-color:rgba(61,220,151,0.08) !important;
-      border-left:3px solid #3ddc97 !important;
+      gap:10px;
+      padding:10px 16px;
       cursor:pointer;
+      transition:all 0.15s;
+      border-left:3px solid transparent;
     }
-
-    /* Currently selected/active entry */
-    .pf-phone-input .iti__country.iti__active{
-      background:rgba(61,220,151,0.06);
+    .phone-country-item:hover{
+      background:rgba(61,220,151,0.08);
+      border-left-color:var(--accent);
     }
-
-    /* Text colors */
-    .pf-phone-input .iti__dial-code{color:rgba(255,255,255,0.6)}
-    .pf-phone-input .iti__country-name{color:#f3f3f3}
-
-    /* Divider */
-    .pf-phone-input .iti__divider{border-bottom:1px solid rgba(255,255,255,0.08)}
-
-    /* Custom scrollbar */
-    .pf-phone-input .iti__country-list::-webkit-scrollbar{
-      width:6px;
-    }
-    .pf-phone-input .iti__country-list::-webkit-scrollbar-thumb{
-      background-color:#333;
-      border-radius:4px;
-    }
+    .phone-country-item .phone-country-flag{font-size:18px}
+    .phone-country-item .phone-country-name{flex:1;color:var(--text);font-size:14px}
+    .phone-country-item .phone-country-dial{color:var(--muted);font-size:14px}
 
     /* Phone error message */
     .phone-error{color:#ff6b6b;font-size:13px;margin-top:4px;display:none}
@@ -199,10 +221,22 @@
           <label>Email</label>
           <input id="email" type="email" disabled />
         </div>
-        <div class="row pf-phone-input">
-          <label>Phone number</label>
-          <input id="phone-number" type="tel" placeholder="+34 600 123 456" required />
+        <div class="row">
+          <label>Phone number*</label>
+          <div class="phone-input-wrapper" data-phone-id="phone-number">
+            <div class="phone-input-row">
+              <button type="button" class="phone-country-button"></button>
+              <span class="phone-prefix"></span>
+              <input type="tel" class="phone-number-input" placeholder="612345678" />
+              <input type="hidden" id="phone-number" name="phone-number" class="phone-number-full" />
+            </div>
+            <div class="phone-dropdown">
+              <input type="text" class="phone-dropdown-search" placeholder="Search country or code…" />
+              <div class="phone-country-list"></div>
+            </div>
+          </div>
           <div id="phone-error" class="phone-error">Please enter a valid phone number.</div>
+          <p style="color:rgba(255,255,255,0.5); font-size:13px; margin:4px 0 0 0">We'll use this to send reminders and notifications later.</p>
         </div>
         <button type="submit">Save Changes</button>
         <p id="profile-status" class="status"></p>
@@ -277,24 +311,12 @@
         document.getElementById('full-name').value = currentUser.full_name || '';
         document.getElementById('email').value = currentUser.email;
 
-        // Initialize intl-tel-input
-        const input = document.querySelector("#phone-number");
-        phoneInput = window.intlTelInput(input, {
-          initialCountry: "auto",
-          geoIpLookup: callback => {
-            fetch('https://ipapi.co/json')
-              .then(res => res.json())
-              .then(data => callback(data.country_code))
-              .catch(() => callback('es'));
-          },
-          nationalMode: false,
-          formatOnDisplay: true,
-          separateDialCode: false,
-          utilsScript: "https://cdn.jsdelivr.net/npm/intl-tel-input@23.0.4/build/js/utils.js"
-        });
+        // Phone input is auto-initialized by PhoneInputManager
+        // Get reference to the instance
+        phoneInput = window.PhoneInputManager.getInstance('phone-number');
 
-        // Set phone number after initializing intl-tel-input
-        if (currentUser.phone_number) {
+        // Set phone number if exists
+        if (currentUser.phone_number && phoneInput) {
           phoneInput.setNumber(currentUser.phone_number);
         }
       } catch (err) {
@@ -429,13 +451,18 @@
         return;
       }
 
-      // Validate phone number using intl-tel-input
+      // Validate phone number
       if (!phoneInput || !phoneInput.isValidNumber()) {
         phoneError.style.display = 'block';
+        if (phoneInput) {
+          phoneInput.setInvalid(true);
+        }
         status.textContent = 'Please fix the errors above';
         status.className = 'status error';
         return;
       }
+      // Clear invalid state if valid
+      phoneInput.setInvalid(false);
 
       // Get phone number in E.164 format
       const phoneNumber = phoneInput.getNumber();


### PR DESCRIPTION
- Remove all intl-tel-input CDN dependencies
- Create custom phone-input.js component with:
  - Country selector button with flag emoji and country name
  - Non-editable dial code prefix display
  - Local number input for digits only
  - Hidden E.164 full number field
  - Custom dark-themed dropdown with search
  - Auto-detection of country from dial code
  - Full E.164 format parsing and validation
- Update app.html Step 1 form with new phone component
- Update profile.html with new phone component
- Maintain consistent dark theme styling with green accents
- Fix alignment with existing form fields
- Keep same validation behavior (required, E.164 format)