### PR TITLE
Update payment due label for repayment types

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -511,7 +511,7 @@
         <!-- One-time payment fields -->
         <div id="one-time-fields">
           <div class="row">
-            <label>First payment due</label>
+            <label>Full repayment due</label>
             <select id="one-time-due-option" onchange="updateOneTimeDueOption()" style="flex:1; padding:10px 12px; border-radius:10px; border:1px solid rgba(255,255,255,0.08); background:#10151d; color:var(--text)">
               <option value="1month">In 1 month</option>
               <option value="2months">In 2 months</option>
@@ -519,7 +519,7 @@
               <option value="custom">Pick a date…</option>
             </select>
           </div>
-          <p style="color:var(--muted); font-size:12px; margin:6px 0 20px 172px">When will the borrower start paying you back?</p>
+          <p style="color:var(--muted); font-size:12px; margin:6px 0 20px 172px">Select when the borrower is expected to repay the full amount in a single payment.</p>
 
           <div id="custom-one-time-due-date" class="hidden" style="margin:16px 0">
             <div class="row">


### PR DESCRIPTION
Changed the label and helper text in Step 2 (Terms) when repayment type is "One-time payment":
- Label: "Full repayment due" (was "First payment due")
- Helper: "Select when the borrower is expected to repay the full amount in a single payment."

Installments section remains unchanged with "First payment due" label.