### PR TITLE
Fix profile page UI issues: Activity button wrapping and phone number…

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -30,11 +30,11 @@
     .app-slogan{color:var(--muted); font-size:14px; line-height:1.2; margin-top:2px}
     .top-header-user-info{color:var(--text); font-size:14px; text-align:right}
     .top-header-actions{display:flex; gap:12px; align-items:center}
-    .logout-btn{padding:8px 16px;border-radius:8px;border:1px solid rgba(255,255,255,0.15);background:transparent;color:var(--text);font-weight:500; cursor:pointer; font-size:14px}
+    .logout-btn{padding:8px 16px;border-radius:8px;border:1px solid rgba(255,255,255,0.15);background:transparent;color:var(--text);font-weight:500; cursor:pointer; font-size:14px; white-space:nowrap; height:36px}
     .logout-btn:hover{background:rgba(255,255,255,0.05)}
-    .inbox-widget{padding:8px 16px;border-radius:8px;border:1px solid rgba(255,255,255,0.15);background:transparent;color:var(--text);font-weight:500;font-size:14px; cursor:pointer; transition:all 0.2s ease}
+    .inbox-widget{padding:8px 16px;border-radius:8px;border:1px solid rgba(255,255,255,0.15);background:transparent;color:var(--text);font-weight:500;font-size:14px; cursor:pointer; transition:all 0.2s ease; white-space:nowrap; height:36px; display:inline-flex; align-items:center}
     .inbox-widget:hover{background:rgba(255,255,255,0.05)}
-    .inbox-widget.inbox-widget-has-unread{background:var(--card);border:1px solid rgba(255,255,255,0.06);border-radius:16px;padding:10px 18px;font-size:15px}
+    .inbox-widget.inbox-widget-has-unread{background:var(--card);border:1px solid rgba(255,255,255,0.06);border-radius:16px;padding:10px 18px;font-size:15px; height:auto}
     .inbox-widget.inbox-widget-has-unread:hover{background:#1a2028}
     .inbox-count{color:var(--accent); font-weight:700}
     .card{background:var(--card);border:1px solid rgba(255,255,255,0.06);border-radius:16px;padding:16px;margin:16px 0}

--- a/public/components/header.html
+++ b/public/components/header.html
@@ -14,7 +14,7 @@
       <div class="inbox-widget" id="activity-button">
         Activity (<span class="inbox-count" id="activity-count">0</span>)
       </div>
-      <a href="/profile" style="color:var(--text); text-decoration:none; padding:8px 16px; border-radius:8px; border:1px solid rgba(255,255,255,0.15); background:transparent; font-weight:500; font-size:14px; display:inline-block; white-space:nowrap">My Profile</a>
+      <a href="/profile" style="color:var(--text); text-decoration:none; padding:8px 16px; border-radius:8px; border:1px solid rgba(255,255,255,0.15); background:transparent; font-weight:500; font-size:14px; display:inline-flex; align-items:center; white-space:nowrap; height:36px">My Profile</a>
       <button class="logout-btn" id="logout-btn">Logout</button>
     </div>
   </div>

--- a/public/profile.html
+++ b/public/profile.html
@@ -35,11 +35,11 @@
     .app-slogan{color:var(--muted); font-size:14px; line-height:1.2; margin-top:2px}
     .top-header-user-info{color:var(--text); font-size:14px; text-align:right}
     .top-header-actions{display:flex; gap:12px; align-items:center}
-    .logout-btn{padding:8px 16px;border-radius:8px;border:1px solid rgba(255,255,255,0.15);background:transparent;color:var(--text);font-weight:500; cursor:pointer; font-size:14px}
+    .logout-btn{padding:8px 16px;border-radius:8px;border:1px solid rgba(255,255,255,0.15);background:transparent;color:var(--text);font-weight:500; cursor:pointer; font-size:14px; white-space:nowrap; height:36px}
     .logout-btn:hover{background:rgba(255,255,255,0.05)}
-    .inbox-widget{padding:8px 16px;border-radius:8px;border:1px solid rgba(255,255,255,0.15);background:transparent;color:var(--text);font-weight:500;font-size:14px; cursor:pointer; transition:all 0.2s ease}
+    .inbox-widget{padding:8px 16px;border-radius:8px;border:1px solid rgba(255,255,255,0.15);background:transparent;color:var(--text);font-weight:500;font-size:14px; cursor:pointer; transition:all 0.2s ease; white-space:nowrap; height:36px; display:inline-flex; align-items:center}
     .inbox-widget:hover{background:rgba(255,255,255,0.05)}
-    .inbox-widget.inbox-widget-has-unread{background:var(--card);border:1px solid rgba(255,255,255,0.06);border-radius:16px;padding:10px 18px;font-size:15px}
+    .inbox-widget.inbox-widget-has-unread{background:var(--card);border:1px solid rgba(255,255,255,0.06);border-radius:16px;padding:10px 18px;font-size:15px; height:auto}
     .inbox-widget.inbox-widget-has-unread:hover{background:#1a2028}
     .inbox-count{color:var(--accent);font-weight:700}
 
@@ -75,7 +75,8 @@
       cursor:pointer;
       transition:all 0.2s;
       white-space:nowrap;
-      min-width:180px;
+      max-width:120px;
+      min-width:100px;
     }
     .phone-country-button:hover,
     .phone-country-button:focus{
@@ -83,8 +84,8 @@
       outline:none;
     }
     .phone-country-flag{font-size:18px}
-    .phone-country-name{flex:1}
-    .phone-caret{font-size:10px;color:var(--muted)}
+    .phone-country-name{flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+    .phone-caret{font-size:10px;color:var(--muted);flex-shrink:0}
 
     /* Prefix display */
     .phone-prefix{

--- a/public/review-details.html
+++ b/public/review-details.html
@@ -96,11 +96,11 @@
     .app-slogan{color:var(--muted); font-size:14px; line-height:1.2; margin-top:2px}
     .top-header-user-info{color:var(--text); font-size:14px; text-align:right}
     .top-header-actions{display:flex; gap:12px; align-items:center}
-    .logout-btn{padding:8px 16px;border-radius:8px;border:1px solid rgba(255,255,255,0.15);background:transparent;color:var(--text);font-weight:500; cursor:pointer; font-size:14px}
+    .logout-btn{padding:8px 16px;border-radius:8px;border:1px solid rgba(255,255,255,0.15);background:transparent;color:var(--text);font-weight:500; cursor:pointer; font-size:14px; white-space:nowrap; height:36px}
     .logout-btn:hover{background:rgba(255,255,255,0.05)}
-    .inbox-widget{padding:8px 16px;border-radius:8px;border:1px solid rgba(255,255,255,0.15);background:transparent;color:var(--text);font-weight:500;font-size:14px;text-decoration:none;display:inline-block;transition:all 0.2s ease}
+    .inbox-widget{padding:8px 16px;border-radius:8px;border:1px solid rgba(255,255,255,0.15);background:transparent;color:var(--text);font-weight:500;font-size:14px;text-decoration:none;display:inline-flex;align-items:center;transition:all 0.2s ease; white-space:nowrap; height:36px}
     .inbox-widget:hover{background:rgba(255,255,255,0.05)}
-    .inbox-widget.inbox-widget-has-unread{background:var(--card);border:1px solid rgba(255,255,255,0.06);border-radius:16px;padding:10px 18px;font-size:15px}
+    .inbox-widget.inbox-widget-has-unread{background:var(--card);border:1px solid rgba(255,255,255,0.06);border-radius:16px;padding:10px 18px;font-size:15px; height:auto}
     .inbox-widget.inbox-widget-has-unread:hover{background:#1a2028}
     .inbox-count{color:var(--accent);font-weight:700}
     .tabs{display:flex; gap:8px; margin-bottom:16px; border-bottom:1px solid rgba(255,255,255,0.08)}

--- a/public/review.html
+++ b/public/review.html
@@ -52,11 +52,11 @@
     .app-slogan{color:var(--muted); font-size:14px; line-height:1.2; margin-top:2px}
     .top-header-user-info{color:var(--text); font-size:14px; text-align:right}
     .top-header-actions{display:flex; gap:12px; align-items:center}
-    .logout-btn{padding:8px 16px;border-radius:8px;border:1px solid rgba(255,255,255,0.15);background:transparent;color:var(--text);font-weight:500; cursor:pointer; font-size:14px}
+    .logout-btn{padding:8px 16px;border-radius:8px;border:1px solid rgba(255,255,255,0.15);background:transparent;color:var(--text);font-weight:500; cursor:pointer; font-size:14px; white-space:nowrap; height:36px}
     .logout-btn:hover{background:rgba(255,255,255,0.05)}
-    .inbox-widget{padding:8px 16px;border-radius:8px;border:1px solid rgba(255,255,255,0.15);background:transparent;color:var(--text);font-weight:500;font-size:14px;text-decoration:none;display:inline-block;transition:all 0.2s ease}
+    .inbox-widget{padding:8px 16px;border-radius:8px;border:1px solid rgba(255,255,255,0.15);background:transparent;color:var(--text);font-weight:500;font-size:14px;text-decoration:none;display:inline-flex;align-items:center;transition:all 0.2s ease; white-space:nowrap; height:36px}
     .inbox-widget:hover{background:rgba(255,255,255,0.05)}
-    .inbox-widget.inbox-widget-has-unread{background:var(--card);border:1px solid rgba(255,255,255,0.06);border-radius:16px;padding:10px 18px;font-size:15px}
+    .inbox-widget.inbox-widget-has-unread{background:var(--card);border:1px solid rgba(255,255,255,0.06);border-radius:16px;padding:10px 18px;font-size:15px; height:auto}
     .inbox-widget.inbox-widget-has-unread:hover{background:#1a2028}
     .inbox-count{color:var(--accent);font-weight:700}
   </style>


### PR DESCRIPTION
… section layout

- Add white-space:nowrap to Activity button to prevent text wrapping
- Set consistent height (36px) across all header buttons (Activity, My Profile, Logout)
- Update .inbox-widget to use inline-flex with align-items:center for proper alignment
- Reduce phone country selector width from min-width:180px to max-width:120px
- Add text-overflow:ellipsis to .phone-country-name for proper truncation
- Apply consistent styling across all pages (app.html, profile.html, review.html, review-details.html)

These changes ensure the header buttons maintain consistent height and don't wrap, while the phone input section has a more balanced layout with a narrower country selector.