### PR TITLE
Fix input background flashing white on focus/autofill

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -41,6 +41,17 @@
     .row{display:flex; gap:12px; align-items:center; margin:10px 0}
     .row label{width:160px; color:var(--muted)}
     .row input{flex:1; padding:10px 12px; border-radius:10px; border:1px solid rgba(255,255,255,0.08); background:#10151d; color:var(--text)}
+    .row input:focus{outline:none; border-color:var(--accent); background:#10151d}
+    .row input:hover{background:#10151d}
+    .row input:-webkit-autofill,
+    .row input:-webkit-autofill:hover,
+    .row input:-webkit-autofill:focus,
+    .row input:-webkit-autofill:active{
+      -webkit-background-clip:text;
+      -webkit-text-fill-color:var(--text);
+      transition:background-color 5000s ease-in-out 0s;
+      box-shadow:inset 0 0 20px 20px #10151d;
+    }
     button{padding:10px 14px;border-radius:10px;border:0;background:var(--accent);color:#0d130f;font-weight:700; cursor:pointer}
     button:hover{filter:brightness(1.06)}
     button.secondary{background:transparent; border:1px solid rgba(255,255,255,0.15); color:var(--text); margin-left:8px}
@@ -207,6 +218,17 @@
     .phone-number-input:focus{
       outline:none;
       border-color:rgba(61,220,151,0.4);
+      background:#10151d;
+    }
+    .phone-number-input:hover{background:#10151d}
+    .phone-number-input:-webkit-autofill,
+    .phone-number-input:-webkit-autofill:hover,
+    .phone-number-input:-webkit-autofill:focus,
+    .phone-number-input:-webkit-autofill:active{
+      -webkit-background-clip:text;
+      -webkit-text-fill-color:var(--text);
+      transition:background-color 5000s ease-in-out 0s;
+      box-shadow:inset 0 0 20px 20px #10151d;
     }
     .phone-number-input.phone-input-invalid{
       border-color:#ff6b6b;
@@ -247,6 +269,17 @@
     .phone-dropdown-search:focus{
       outline:none;
       border-color:rgba(61,220,151,0.4);
+      background:#10151d;
+    }
+    .phone-dropdown-search:hover{background:#10151d}
+    .phone-dropdown-search:-webkit-autofill,
+    .phone-dropdown-search:-webkit-autofill:hover,
+    .phone-dropdown-search:-webkit-autofill:focus,
+    .phone-dropdown-search:-webkit-autofill:active{
+      -webkit-background-clip:text;
+      -webkit-text-fill-color:var(--text);
+      transition:background-color 5000s ease-in-out 0s;
+      box-shadow:inset 0 0 20px 20px #10151d;
     }
     .phone-dropdown-search::placeholder{
       color:var(--muted);

--- a/public/index.html
+++ b/public/index.html
@@ -18,6 +18,17 @@
     .row{display:flex; gap:12px; align-items:center; margin:10px 0}
     .row label{width:160px; color:var(--muted)}
     .row input{flex:1; padding:10px 12px; border-radius:10px; border:1px solid rgba(255,255,255,0.08); background:#10151d; color:var(--text)}
+    .row input:focus{outline:none; border-color:var(--accent); background:#10151d}
+    .row input:hover{background:#10151d}
+    .row input:-webkit-autofill,
+    .row input:-webkit-autofill:hover,
+    .row input:-webkit-autofill:focus,
+    .row input:-webkit-autofill:active{
+      -webkit-background-clip:text;
+      -webkit-text-fill-color:var(--text);
+      transition:background-color 5000s ease-in-out 0s;
+      box-shadow:inset 0 0 20px 20px #10151d;
+    }
     button{padding:10px 14px;border-radius:10px;border:0;background:var(--accent);color:#0d130f;font-weight:700; cursor:pointer}
     button:hover{filter:brightness(1.06)}
     table{width:100%;border-collapse:collapse;margin-top:8px}

--- a/public/login.html
+++ b/public/login.html
@@ -50,6 +50,17 @@
     .row{margin:16px 0}
     .row label{display:block; margin-bottom:6px; color:var(--muted); font-size:14px}
     .row input{width:100%; padding:12px; border-radius:10px; border:1px solid rgba(255,255,255,0.08); background:#10151d; color:var(--text); font-size:15px}
+    .row input:focus{outline:none; border-color:var(--accent); background:#10151d}
+    .row input:hover{background:#10151d}
+    .row input:-webkit-autofill,
+    .row input:-webkit-autofill:hover,
+    .row input:-webkit-autofill:focus,
+    .row input:-webkit-autofill:active{
+      -webkit-background-clip:text;
+      -webkit-text-fill-color:var(--text);
+      transition:background-color 5000s ease-in-out 0s;
+      box-shadow:inset 0 0 20px 20px #10151d;
+    }
     button{width:100%; padding:12px;border-radius:10px;border:0;background:var(--accent);color:#0d130f;font-weight:700; cursor:pointer; font-size:15px; margin-top:8px}
     button:hover{filter:brightness(1.06)}
     .status{color:var(--muted); margin-top:12px; min-height:1.2em; font-size:14px;}

--- a/public/profile.html
+++ b/public/profile.html
@@ -19,6 +19,17 @@
     .row{margin:20px 0}
     .row label{display:block; margin-bottom:8px; color:var(--muted); font-size:14px; font-weight:500}
     .row input{width:100%; padding:12px; border-radius:10px; border:1px solid rgba(255,255,255,0.08); background:#10151d; color:var(--text); font-size:15px}
+    .row input:focus{outline:none; border-color:var(--accent); background:#10151d}
+    .row input:hover{background:#10151d}
+    .row input:-webkit-autofill,
+    .row input:-webkit-autofill:hover,
+    .row input:-webkit-autofill:focus,
+    .row input:-webkit-autofill:active{
+      -webkit-background-clip:text;
+      -webkit-text-fill-color:var(--text);
+      transition:background-color 5000s ease-in-out 0s;
+      box-shadow:inset 0 0 20px 20px #10151d;
+    }
     .row input:disabled{opacity:0.6; cursor:not-allowed}
     button{width:100%; padding:12px;border-radius:10px;border:0;background:var(--accent);color:#0d130f;font-weight:700; cursor:pointer; font-size:15px; margin-top:8px}
     button:hover{filter:brightness(1.06)}
@@ -113,6 +124,17 @@
     .phone-number-input:focus{
       outline:none;
       border-color:rgba(61,220,151,0.4);
+      background:#10151d;
+    }
+    .phone-number-input:hover{background:#10151d}
+    .phone-number-input:-webkit-autofill,
+    .phone-number-input:-webkit-autofill:hover,
+    .phone-number-input:-webkit-autofill:focus,
+    .phone-number-input:-webkit-autofill:active{
+      -webkit-background-clip:text;
+      -webkit-text-fill-color:var(--text);
+      transition:background-color 5000s ease-in-out 0s;
+      box-shadow:inset 0 0 20px 20px #10151d;
     }
     .phone-number-input.phone-input-invalid{
       border-color:#ff6b6b;
@@ -153,6 +175,17 @@
     .phone-dropdown-search:focus{
       outline:none;
       border-color:rgba(61,220,151,0.4);
+      background:#10151d;
+    }
+    .phone-dropdown-search:hover{background:#10151d}
+    .phone-dropdown-search:-webkit-autofill,
+    .phone-dropdown-search:-webkit-autofill:hover,
+    .phone-dropdown-search:-webkit-autofill:focus,
+    .phone-dropdown-search:-webkit-autofill:active{
+      -webkit-background-clip:text;
+      -webkit-text-fill-color:var(--text);
+      transition:background-color 5000s ease-in-out 0s;
+      box-shadow:inset 0 0 20px 20px #10151d;
     }
     .phone-dropdown-search::placeholder{
       color:var(--muted);

--- a/public/review-details.html
+++ b/public/review-details.html
@@ -55,8 +55,30 @@
     .form-checkbox input{margin-right:8px}
     .form-checkbox label{cursor:pointer; color:var(--text); font-size:14px}
     textarea{width:100%; padding:12px; border-radius:8px; border:1px solid rgba(255,255,255,0.15); background:var(--bg); color:var(--text); font-family:inherit; font-size:14px; resize:vertical; min-height:80px}
+    textarea:focus{outline:none; border-color:var(--accent); background:var(--bg)}
+    textarea:hover{background:var(--bg)}
+    textarea:-webkit-autofill,
+    textarea:-webkit-autofill:hover,
+    textarea:-webkit-autofill:focus,
+    textarea:-webkit-autofill:active{
+      -webkit-background-clip:text;
+      -webkit-text-fill-color:var(--text);
+      transition:background-color 5000s ease-in-out 0s;
+      box-shadow:inset 0 0 20px 20px var(--bg);
+    }
     textarea::placeholder{color:var(--muted)}
     input[type="number"]{width:100%; padding:12px; border-radius:8px; border:1px solid rgba(255,255,255,0.15); background:var(--bg); color:var(--text); font-family:inherit; font-size:14px}
+    input[type="number"]:focus{outline:none; border-color:var(--accent); background:var(--bg)}
+    input[type="number"]:hover{background:var(--bg)}
+    input[type="number"]:-webkit-autofill,
+    input[type="number"]:-webkit-autofill:hover,
+    input[type="number"]:-webkit-autofill:focus,
+    input[type="number"]:-webkit-autofill:active{
+      -webkit-background-clip:text;
+      -webkit-text-fill-color:var(--text);
+      transition:background-color 5000s ease-in-out 0s;
+      box-shadow:inset 0 0 20px 20px var(--bg);
+    }
     input[type="number"]::placeholder{color:var(--muted)}
     .summary-box{background:rgba(61,220,151,0.05); border:1px solid rgba(61,220,151,0.15); border-radius:12px; padding:20px; margin:20px 0}
     .summary-item{margin:8px 0; color:var(--text); font-size:14px}

--- a/public/review.html
+++ b/public/review.html
@@ -25,6 +25,17 @@
     .row{display:flex; gap:12px; align-items:center; margin:12px 0}
     .row label{width:120px; color:var(--muted); font-size:14px}
     .row input{flex:1; padding:10px 12px; border-radius:10px; border:1px solid rgba(255,255,255,0.08); background:#10151d; color:var(--text)}
+    .row input:focus{outline:none; border-color:var(--accent); background:#10151d}
+    .row input:hover{background:#10151d}
+    .row input:-webkit-autofill,
+    .row input:-webkit-autofill:hover,
+    .row input:-webkit-autofill:focus,
+    .row input:-webkit-autofill:active{
+      -webkit-background-clip:text;
+      -webkit-text-fill-color:var(--text);
+      transition:background-color 5000s ease-in-out 0s;
+      box-shadow:inset 0 0 20px 20px #10151d;
+    }
     button{padding:12px 20px; border-radius:10px; border:0; background:var(--accent); color:#0d130f; font-weight:700; cursor:pointer; font-size:14px; width:100%}
     button:hover{filter:brightness(1.06)}
     button.secondary{background:transparent; border:1px solid rgba(255,255,255,0.15); color:var(--text); margin-top:8px}


### PR DESCRIPTION
- Add consistent dark background (#10151d or var(--bg)) for all input states
- Prevent autofill from overriding background with white color
- Add focus states that maintain dark theme with accent border
- Add hover states to ensure dark background persistence
- Apply fixes to all input fields across:
  - login.html (login/signup forms)
  - profile.html (profile form + phone inputs)
  - app.html (new agreement form + phone inputs)
  - review.html (review form inputs)
  - review-details.html (textarea and number inputs)
  - index.html (demo form inputs)

Fixes autofill issue on Chrome/Safari using webkit box-shadow technique and transition delay to prevent background color override.