### PR TITLE
Fix profile page header alignment and phone country dropdown width

### DIFF
--- a/public/components/header.html
+++ b/public/components/header.html
@@ -15,7 +15,7 @@
         Activity (<span class="inbox-count" id="activity-count">0</span>)
       </div>
       <a href="/profile" style="color:var(--text); text-decoration:none; padding:8px 16px; border-radius:8px; border:1px solid rgba(255,255,255,0.15); background:transparent; font-weight:500; font-size:14px; display:inline-flex; align-items:center; white-space:nowrap; height:36px">My Profile</a>
-      <button class="logout-btn" id="logout-btn">Logout</button>
+      <button class="logout-btn" id="logout-btn" style="display:inline-flex; align-items:center; justify-content:center">Logout</button>
     </div>
   </div>
 </header>

--- a/public/profile.html
+++ b/public/profile.html
@@ -86,8 +86,8 @@
       cursor:pointer;
       transition:all 0.2s;
       white-space:nowrap;
-      max-width:120px;
-      min-width:100px;
+      width:auto;
+      min-width:200px;
     }
     .phone-country-button:hover,
     .phone-country-button:focus{
@@ -95,7 +95,7 @@
       outline:none;
     }
     .phone-country-flag{font-size:18px}
-    .phone-country-name{flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+    .phone-country-name{flex:1;white-space:nowrap}
     .phone-caret{font-size:10px;color:var(--muted);flex-shrink:0}
 
     /* Prefix display */


### PR DESCRIPTION
- Add flex centering to Logout button for consistent vertical alignment with Activity and My Profile buttons
- Increase phone country dropdown min-width from 100px to 200px to fully display "United Kingdom"
- Remove max-width restriction and text truncation from country name display
- Changes apply across all pages using the shared header component