### PR TITLE
Align country dropdown height with adjacent input fields

### DIFF
--- a/public/profile.html
+++ b/public/profile.html
@@ -72,11 +72,12 @@
 
     /* Custom Phone Input Widget */
     .phone-input-wrapper{position:relative}
-    .phone-input-row{display:flex;gap:8px;align-items:stretch}
+    .phone-input-row{display:flex;gap:8px;align-items:center}
 
     /* Country button */
     .phone-country-button{
       display:flex;align-items:center;gap:8px;
+      height:40px;
       padding:0 12px;
       background:#10151d;
       border:1px solid rgba(255,255,255,0.12);
@@ -101,6 +102,7 @@
     /* Prefix display */
     .phone-prefix{
       display:flex;align-items:center;
+      height:40px;
       padding:0 12px;
       background:#10151d;
       border:1px solid rgba(255,255,255,0.12);
@@ -114,7 +116,8 @@
     /* Local number input */
     .phone-number-input{
       flex:1;
-      padding:12px;
+      height:40px;
+      padding:0 12px;
       background:#10151d;
       border:1px solid rgba(255,255,255,0.12);
       border-radius:10px;


### PR DESCRIPTION
Normalized all phone input elements to have consistent 40px height:
- Set explicit height:40px on country dropdown, dial-code prefix, and phone input
- Changed padding from 12px to 0 12px for consistent vertical alignment
- Updated flex container to use align-items:center instead of stretch
- All fields now perfectly aligned with identical height and spacing