### PR TITLE
Fix installment summary reactivity when loan amount changes

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -492,7 +492,7 @@
 
         <div class="row">
           <label>Loan amount (€)</label>
-          <input id="amount" type="text" placeholder="e.g. 6.000" required onblur="formatAmountInput(); validateAmountField();" onfocus="unformatAmountInput()" oninput="updateOneTimeEstimate()" />
+          <input id="amount" type="text" placeholder="e.g. 6.000" required onblur="formatAmountInput(); validateAmountField();" onfocus="unformatAmountInput()" oninput="updateEstimate()" />
         </div>
         <p style="color:var(--muted); font-size:12px; margin:6px 0 4px 172px">Enter the amount in euros.</p>
         <p id="amount-error" class="hidden" style="color:#f87171; font-size:13px; margin:0 0 16px 172px"></p>
@@ -1619,6 +1619,19 @@
 
       document.getElementById('one-time-estimate').textContent =
         `1 payment of about €${amountFormatted} on ${dateFormatted}, excluding interest.`;
+    }
+
+    // Unified function to update estimate based on repayment type
+    function updateEstimate() {
+      const repaymentType = document.querySelector('input[name="repayment-type"]:checked').value;
+
+      if (repaymentType === 'installments') {
+        // For installments, recalculate the installment summary
+        calculateInstallments();
+      } else {
+        // For one-time payment, update the one-time estimate
+        updateOneTimeEstimate();
+      }
     }
 
     // Helper function to add months while keeping day-of-month (or last valid day)


### PR DESCRIPTION
The installment summary was not updating when the loan amount field changed. This was because the amount field's oninput handler only called updateOneTimeEstimate(), which doesn't recalculate installments.

Changes:
- Add updateEstimate() function that dispatches to the correct handler based on repayment type (one-time vs installments)
- Update amount field's oninput handler to call updateEstimate()
- Now changing loan amount instantly updates the installment summary (payment amount, plan length, and dates)

The summary now reacts to all input changes:
- Loan amount → payment amount updates
- Duration/unit → plan end date updates
- Number of payments → payment frequency updates
- First payment date → plan start/end dates update