### PR TITLE
Fix profile page alignment with normalized control classes

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>PayFriends — My Agreements</title>
   <script src="https://cdn.jsdelivr.net/npm/qrcodejs@1.0.0/qrcode.min.js"></script>
+  <!-- Shared control styles -->
+  <link rel="stylesheet" href="/css/shared-controls.css" />
   <!-- Shared header component -->
   <script src="/js/header.js"></script>
   <!-- Phone input component -->
@@ -30,12 +32,6 @@
     .app-slogan{color:var(--muted); font-size:14px; line-height:1.2; margin-top:2px}
     .top-header-user-info{color:var(--text); font-size:14px; text-align:right}
     .top-header-actions{display:flex; gap:12px; align-items:center}
-    .logout-btn{padding:8px 16px;border-radius:8px;border:1px solid rgba(255,255,255,0.15);background:transparent;color:var(--text);font-weight:500; cursor:pointer; font-size:14px; white-space:nowrap; height:36px}
-    .logout-btn:hover{background:rgba(255,255,255,0.05)}
-    .inbox-widget{padding:8px 16px;border-radius:8px;border:1px solid rgba(255,255,255,0.15);background:transparent;color:var(--text);font-weight:500;font-size:14px; cursor:pointer; transition:all 0.2s ease; white-space:nowrap; height:36px; display:inline-flex; align-items:center}
-    .inbox-widget:hover{background:rgba(255,255,255,0.05)}
-    .inbox-widget.inbox-widget-has-unread{background:var(--card);border:1px solid rgba(255,255,255,0.06);border-radius:8px;padding:8px 16px;font-size:14px; height:36px}
-    .inbox-widget.inbox-widget-has-unread:hover{background:#1a2028}
     .inbox-count{color:var(--accent); font-weight:700}
     .card{background:var(--card);border:1px solid rgba(255,255,255,0.06);border-radius:16px;padding:16px;margin:16px 0}
     .row{display:flex; gap:12px; align-items:center; margin:10px 0}

--- a/public/components/header.html
+++ b/public/components/header.html
@@ -11,11 +11,11 @@
   <div class="top-header-right">
     <div class="top-header-user-info" id="user-info-display">Loading...</div>
     <div class="top-header-actions">
-      <div class="inbox-widget" id="activity-button">
+      <div class="pf-btn-header" id="activity-button">
         Activity (<span class="inbox-count" id="activity-count">0</span>)
       </div>
-      <a href="/profile" style="color:var(--text); text-decoration:none; padding:8px 16px; border-radius:8px; border:1px solid rgba(255,255,255,0.15); background:transparent; font-weight:500; font-size:14px; display:inline-flex; align-items:center; white-space:nowrap; height:36px">My Profile</a>
-      <button class="logout-btn" id="logout-btn" style="display:inline-flex; align-items:center; justify-content:center">Logout</button>
+      <a href="/profile" class="pf-btn-header">My Profile</a>
+      <button class="pf-btn-header" id="logout-btn">Logout</button>
     </div>
   </div>
 </header>

--- a/public/css/shared-controls.css
+++ b/public/css/shared-controls.css
@@ -1,0 +1,171 @@
+/* PayFriends Shared Control Styles - Normalize height & baseline across browsers */
+
+/* Base control normalization - for inputs and select-like controls */
+.pf-control {
+  height: 40px;
+  min-height: 40px;
+  padding: 0 12px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: #10151d;
+  color: var(--text);
+  font-size: 15px;
+  box-sizing: border-box;
+  outline: none;
+  align-middle: middle;
+  vertical-align: middle;
+  line-height: normal;
+  font-family: system-ui, -apple-system, Segoe UI, Arial, sans-serif;
+}
+
+.pf-control:focus {
+  border-color: rgba(61, 220, 151, 0.4);
+  outline: none;
+}
+
+.pf-control:hover {
+  background: #10151d;
+}
+
+/* Header buttons - normalize all interactive elements in header */
+.pf-btn-header {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 36px;
+  min-height: 36px;
+  padding: 0 16px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text);
+  background: transparent;
+  white-space: nowrap;
+  vertical-align: middle;
+  line-height: normal;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  text-decoration: none;
+  box-sizing: border-box;
+}
+
+.pf-btn-header:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.pf-btn-header:focus {
+  outline: none;
+}
+
+/* Special styling for activity button with counter */
+.pf-btn-header.has-unread {
+  background: var(--card);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.pf-btn-header.has-unread:hover {
+  background: #1a2028;
+}
+
+/* Phone input controls - ensure all three elements align perfectly */
+.pf-phone-row {
+  display: flex;
+  gap: 8px;
+  align-items: stretch;
+  flex-wrap: wrap;
+}
+
+@media (min-width: 640px) {
+  .pf-phone-row {
+    flex-wrap: nowrap;
+  }
+}
+
+/* Country select button */
+.pf-phone-country {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 40px;
+  min-height: 40px;
+  padding: 0 12px;
+  background: #10151d;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 10px;
+  color: var(--text);
+  font-size: 15px;
+  cursor: pointer;
+  transition: all 0.2s;
+  white-space: nowrap;
+  min-width: 200px;
+  box-sizing: border-box;
+  vertical-align: middle;
+  line-height: normal;
+}
+
+.pf-phone-country:hover,
+.pf-phone-country:focus {
+  border-color: rgba(61, 220, 151, 0.4);
+  outline: none;
+}
+
+/* Dial code prefix display */
+.pf-phone-prefix {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 40px;
+  min-height: 40px;
+  padding: 0 12px;
+  background: #10151d;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 10px;
+  color: var(--muted);
+  font-size: 15px;
+  min-width: 60px;
+  box-sizing: border-box;
+  vertical-align: middle;
+  line-height: normal;
+}
+
+/* Phone number input */
+.pf-phone-input {
+  flex: 1;
+  height: 40px;
+  min-height: 40px;
+  padding: 0 12px;
+  background: #10151d;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 10px;
+  color: var(--text);
+  font-size: 15px;
+  font-family: system-ui, -apple-system, Segoe UI, Arial, sans-serif;
+  box-sizing: border-box;
+  vertical-align: middle;
+  line-height: normal;
+}
+
+.pf-phone-input:focus {
+  outline: none;
+  border-color: rgba(61, 220, 151, 0.4);
+  background: #10151d;
+}
+
+.pf-phone-input:hover {
+  background: #10151d;
+}
+
+.pf-phone-input:-webkit-autofill,
+.pf-phone-input:-webkit-autofill:hover,
+.pf-phone-input:-webkit-autofill:focus,
+.pf-phone-input:-webkit-autofill:active {
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: var(--text);
+  transition: background-color 5000s ease-in-out 0s;
+  box-shadow: inset 0 0 20px 20px #10151d;
+}
+
+.pf-phone-input.phone-input-invalid {
+  border-color: #ff6b6b;
+}

--- a/public/profile.html
+++ b/public/profile.html
@@ -4,6 +4,8 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>PayFriends — My Profile</title>
+  <!-- Shared control styles -->
+  <link rel="stylesheet" href="/css/shared-controls.css" />
   <!-- Shared header component -->
   <script src="/js/header.js"></script>
   <!-- Phone input component -->
@@ -46,12 +48,6 @@
     .app-slogan{color:var(--muted); font-size:14px; line-height:1.2; margin-top:2px}
     .top-header-user-info{color:var(--text); font-size:14px; text-align:right}
     .top-header-actions{display:flex; gap:12px; align-items:center}
-    .logout-btn{padding:8px 16px;border-radius:8px;border:1px solid rgba(255,255,255,0.15);background:transparent;color:var(--text);font-weight:500; cursor:pointer; font-size:14px; white-space:nowrap; height:36px}
-    .logout-btn:hover{background:rgba(255,255,255,0.05)}
-    .inbox-widget{padding:8px 16px;border-radius:8px;border:1px solid rgba(255,255,255,0.15);background:transparent;color:var(--text);font-weight:500;font-size:14px; cursor:pointer; transition:all 0.2s ease; white-space:nowrap; height:36px; display:inline-flex; align-items:center}
-    .inbox-widget:hover{background:rgba(255,255,255,0.05)}
-    .inbox-widget.inbox-widget-has-unread{background:var(--card);border:1px solid rgba(255,255,255,0.06);border-radius:8px;padding:8px 16px;font-size:14px; height:36px}
-    .inbox-widget.inbox-widget-has-unread:hover{background:#1a2028}
     .inbox-count{color:var(--accent);font-weight:700}
 
     /* Avatar styles */
@@ -72,80 +68,9 @@
 
     /* Custom Phone Input Widget */
     .phone-input-wrapper{position:relative}
-    .phone-input-row{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
-    @media (min-width:640px){
-      .phone-input-row{flex-wrap:nowrap}
-    }
-
-    /* Country button */
-    .phone-country-button{
-      display:flex;align-items:center;gap:8px;
-      height:40px;
-      padding:0 12px;
-      background:#10151d;
-      border:1px solid rgba(255,255,255,0.12);
-      border-radius:10px;
-      color:var(--text);
-      font-size:15px;
-      cursor:pointer;
-      transition:all 0.2s;
-      white-space:nowrap;
-      width:auto;
-      min-width:200px;
-    }
-    .phone-country-button:hover,
-    .phone-country-button:focus{
-      border-color:rgba(61,220,151,0.4);
-      outline:none;
-    }
     .phone-country-flag{font-size:18px}
     .phone-country-name{flex:1;white-space:nowrap}
     .phone-caret{font-size:10px;color:var(--muted);flex-shrink:0}
-
-    /* Prefix display */
-    .phone-prefix{
-      display:flex;align-items:center;
-      height:40px;
-      padding:0 12px;
-      background:#10151d;
-      border:1px solid rgba(255,255,255,0.12);
-      border-radius:10px;
-      color:var(--muted);
-      font-size:15px;
-      min-width:60px;
-      justify-content:center;
-    }
-
-    /* Local number input */
-    .phone-number-input{
-      flex:1;
-      height:40px;
-      padding:0 12px;
-      background:#10151d;
-      border:1px solid rgba(255,255,255,0.12);
-      border-radius:10px;
-      color:var(--text);
-      font-size:15px;
-      font-family:system-ui,-apple-system,Segoe UI,Arial,sans-serif;
-    }
-    .phone-number-input:focus{
-      outline:none;
-      border-color:rgba(61,220,151,0.4);
-      background:#10151d;
-    }
-    .phone-number-input:hover{background:#10151d}
-    .phone-number-input:-webkit-autofill,
-    .phone-number-input:-webkit-autofill:hover,
-    .phone-number-input:-webkit-autofill:focus,
-    .phone-number-input:-webkit-autofill:active{
-      -webkit-background-clip:text;
-      -webkit-text-fill-color:var(--text);
-      transition:background-color 5000s ease-in-out 0s;
-      box-shadow:inset 0 0 20px 20px #10151d;
-    }
-    .phone-number-input.phone-input-invalid{
-      border-color:#ff6b6b;
-    }
 
     /* Hidden full number field */
     .phone-number-full{display:none}
@@ -264,10 +189,10 @@
         <div class="row">
           <label>Phone number</label>
           <div class="phone-input-wrapper" data-phone-id="phone-number">
-            <div class="phone-input-row">
-              <button type="button" class="phone-country-button"></button>
-              <span class="phone-prefix"></span>
-              <input type="tel" class="phone-number-input" placeholder="612345678" />
+            <div class="pf-phone-row">
+              <button type="button" class="pf-phone-country phone-country-button"></button>
+              <span class="pf-phone-prefix phone-prefix"></span>
+              <input type="tel" class="pf-phone-input phone-number-input" placeholder="612345678" />
               <input type="hidden" id="phone-number" name="phone-number" class="phone-number-full" />
             </div>
             <div class="phone-dropdown">

--- a/public/review-details.html
+++ b/public/review-details.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>PayFriends — Agreement Details</title>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
+  <!-- Shared control styles -->
+  <link rel="stylesheet" href="/css/shared-controls.css" />
   <!-- Shared header component -->
   <script src="/js/header.js"></script>
   <style>
@@ -118,12 +120,6 @@
     .app-slogan{color:var(--muted); font-size:14px; line-height:1.2; margin-top:2px}
     .top-header-user-info{color:var(--text); font-size:14px; text-align:right}
     .top-header-actions{display:flex; gap:12px; align-items:center}
-    .logout-btn{padding:8px 16px;border-radius:8px;border:1px solid rgba(255,255,255,0.15);background:transparent;color:var(--text);font-weight:500; cursor:pointer; font-size:14px; white-space:nowrap; height:36px}
-    .logout-btn:hover{background:rgba(255,255,255,0.05)}
-    .inbox-widget{padding:8px 16px;border-radius:8px;border:1px solid rgba(255,255,255,0.15);background:transparent;color:var(--text);font-weight:500;font-size:14px;text-decoration:none;display:inline-flex;align-items:center;transition:all 0.2s ease; white-space:nowrap; height:36px}
-    .inbox-widget:hover{background:rgba(255,255,255,0.05)}
-    .inbox-widget.inbox-widget-has-unread{background:var(--card);border:1px solid rgba(255,255,255,0.06);border-radius:8px;padding:8px 16px;font-size:14px; height:36px}
-    .inbox-widget.inbox-widget-has-unread:hover{background:#1a2028}
     .inbox-count{color:var(--accent);font-weight:700}
     .tabs{display:flex; gap:8px; margin-bottom:16px; border-bottom:1px solid rgba(255,255,255,0.08)}
     .tab{padding:10px 16px; cursor:pointer; color:var(--muted); border-bottom:2px solid transparent; margin-bottom:-1px}

--- a/public/review.html
+++ b/public/review.html
@@ -4,6 +4,8 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>PayFriends — Review Agreement</title>
+  <!-- Shared control styles -->
+  <link rel="stylesheet" href="/css/shared-controls.css" />
   <!-- Shared header component -->
   <script src="/js/header.js"></script>
   <style>
@@ -63,12 +65,6 @@
     .app-slogan{color:var(--muted); font-size:14px; line-height:1.2; margin-top:2px}
     .top-header-user-info{color:var(--text); font-size:14px; text-align:right}
     .top-header-actions{display:flex; gap:12px; align-items:center}
-    .logout-btn{padding:8px 16px;border-radius:8px;border:1px solid rgba(255,255,255,0.15);background:transparent;color:var(--text);font-weight:500; cursor:pointer; font-size:14px; white-space:nowrap; height:36px}
-    .logout-btn:hover{background:rgba(255,255,255,0.05)}
-    .inbox-widget{padding:8px 16px;border-radius:8px;border:1px solid rgba(255,255,255,0.15);background:transparent;color:var(--text);font-weight:500;font-size:14px;text-decoration:none;display:inline-flex;align-items:center;transition:all 0.2s ease; white-space:nowrap; height:36px}
-    .inbox-widget:hover{background:rgba(255,255,255,0.05)}
-    .inbox-widget.inbox-widget-has-unread{background:var(--card);border:1px solid rgba(255,255,255,0.06);border-radius:8px;padding:8px 16px;font-size:14px; height:36px}
-    .inbox-widget.inbox-widget-has-unread:hover{background:#1a2028}
     .inbox-count{color:var(--accent);font-weight:700}
   </style>
 </head>


### PR DESCRIPTION
Implement alternative alignment fix for header buttons and phone input row:
- Create shared-controls.css with normalized control classes (pf-btn-header, pf-phone-row, etc.)
- Set explicit height (36px for header, 40px for phone inputs) with line-height: normal
- Use align-middle and vertical-align: middle to eliminate baseline drift
- Update header buttons (Activity, My Profile, Logout) to use pf-btn-header class
- Update phone input row to use pf-phone-row with pf-phone-country, pf-phone-prefix, and pf-phone-input
- Remove conflicting styles from all HTML pages
- Link shared CSS in all pages that use the header component

This ensures perfect alignment across all browsers and zoom levels.