### PR TITLE
fix(review): invite page loads full agreement data and shows complete…

### DIFF
--- a/server.js
+++ b/server.js
@@ -2096,7 +2096,26 @@ app.get('/api/invites/:token', (req, res) => {
         repayment_type: invite.repayment_type,
         amount_cents: invite.amount_cents,
         due_date: invite.due_date,
-        status: invite.status
+        status: invite.status,
+        description: invite.description,
+        money_sent_date: invite.money_sent_date,
+        installment_count: invite.installment_count,
+        installment_amount: invite.installment_amount,
+        first_payment_date: invite.first_payment_date,
+        final_due_date: invite.final_due_date,
+        interest_rate: invite.interest_rate,
+        total_interest: invite.total_interest,
+        total_repay_amount: invite.total_repay_amount,
+        payment_preference_method: invite.payment_preference_method,
+        reminder_enabled: invite.reminder_enabled,
+        plan_length: invite.plan_length,
+        plan_unit: invite.plan_unit,
+        payment_other_description: invite.payment_other_description,
+        reminder_mode: invite.reminder_mode,
+        reminder_offsets: invite.reminder_offsets,
+        proof_required: invite.proof_required,
+        debt_collection_clause: invite.debt_collection_clause,
+        created_at: invite.created_at
       },
       lender: lender || null
     });


### PR DESCRIPTION
… summary fields

The invite review page was showing "—" placeholders instead of real data because the API endpoint /api/invites/:token was only returning a limited subset of agreement fields.

Changes:
- Updated GET /api/invites/:token to return all agreement fields needed for the review summary, including:
  - description, money_sent_date, installment details
  - interest_rate, total_repay_amount, payment preferences
  - reminder settings, proof requirements, debt collection clause

The review.html page already had all the logic to display these fields correctly (including the installment plan summary, interest calculation accordion with schedule table, and payments & reminders section). It just needed the complete data from the API.

Now the invite review page displays:
- All 5 summary fields with real data (no more "—" placeholders)
- Interest, payment calculation & installment schedule accordion (when interest > 0)
- Payments & reminders accordion with full preferences
- Values match Step 5 exactly for the same agreement

Fixes: #98