### PR TITLE
Fix profile header and phone row alignment

### DIFF
--- a/public/css/shared-controls.css
+++ b/public/css/shared-controls.css
@@ -12,9 +12,8 @@
   font-size: 15px;
   box-sizing: border-box;
   outline: none;
-  align-middle: middle;
   vertical-align: middle;
-  line-height: normal;
+  line-height: 1;
   font-family: system-ui, -apple-system, Segoe UI, Arial, sans-serif;
 }
 
@@ -32,8 +31,8 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  height: 36px;
-  min-height: 36px;
+  height: 40px;
+  min-height: 40px;
   padding: 0 16px;
   border-radius: 8px;
   border: 1px solid rgba(255, 255, 255, 0.15);
@@ -43,7 +42,7 @@
   background: transparent;
   white-space: nowrap;
   vertical-align: middle;
-  line-height: normal;
+  line-height: 1;
   cursor: pointer;
   transition: all 0.2s ease;
   text-decoration: none;
@@ -98,10 +97,11 @@
   cursor: pointer;
   transition: all 0.2s;
   white-space: nowrap;
-  min-width: 200px;
+  width: auto;
+  min-width: 220px;
   box-sizing: border-box;
   vertical-align: middle;
-  line-height: normal;
+  line-height: 1;
 }
 
 .pf-phone-country:hover,
@@ -123,10 +123,11 @@
   border-radius: 10px;
   color: var(--muted);
   font-size: 15px;
-  min-width: 60px;
+  width: 80px;
+  min-width: 80px;
   box-sizing: border-box;
   vertical-align: middle;
-  line-height: normal;
+  line-height: 1;
 }
 
 /* Phone number input */
@@ -143,7 +144,7 @@
   font-family: system-ui, -apple-system, Segoe UI, Arial, sans-serif;
   box-sizing: border-box;
   vertical-align: middle;
-  line-height: normal;
+  line-height: 1;
 }
 
 .pf-phone-input:focus {
@@ -168,4 +169,36 @@
 
 .pf-phone-input.phone-input-invalid {
   border-color: #ff6b6b;
+}
+
+/* Universal autofill normalization for all controls */
+.pf-control:-webkit-autofill,
+.pf-control:-webkit-autofill:hover,
+.pf-control:-webkit-autofill:focus,
+.pf-control:-webkit-autofill:active,
+input:-webkit-autofill,
+input:-webkit-autofill:hover,
+input:-webkit-autofill:focus,
+input:-webkit-autofill:active,
+textarea:-webkit-autofill,
+textarea:-webkit-autofill:hover,
+textarea:-webkit-autofill:focus,
+textarea:-webkit-autofill:active,
+select:-webkit-autofill,
+select:-webkit-autofill:hover,
+select:-webkit-autofill:focus,
+select:-webkit-autofill:active {
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: var(--text);
+  transition: background-color 5000s ease-in-out 0s;
+  box-shadow: inset 0 0 20px 20px #10151d !important;
+}
+
+/* Consistent green focus ring for all controls */
+.pf-control:focus,
+.pf-phone-country:focus,
+.pf-phone-input:focus,
+.pf-btn-header:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(61, 220, 151, 0.5);
 }


### PR DESCRIPTION
…t fits 'United Kingdom' and controls align

- Increase header button height from 36px to 40px for consistent alignment
- Widen country select min-width from 200px to 220px to display "United Kingdom" fully
- Normalize all control line-heights to "1" (from "normal") for perfect baseline alignment
- Set dial code prefix to fixed 80px width for better spacing
- Add universal autofill normalization to prevent white flash in Chrome/Safari
- Add consistent green focus ring (rgba(61, 220, 151, 0.5)) for all controls
- Use box-sizing: border-box and vertical-align: middle throughout
- Ensure phone row controls (country + dial code + number) stay on same line with identical heights