### PR TITLE
Fix interest bug and unify payment schedules

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -1818,6 +1818,39 @@
       }
     }
 
+    // Determine payment frequency code for schedule calculation
+    function getPaymentFrequency(loanDurationValue, loanDurationUnit, numRepayments) {
+      // Convert to days
+      let totalDays;
+      switch (loanDurationUnit) {
+        case 'days': totalDays = loanDurationValue; break;
+        case 'weeks': totalDays = loanDurationValue * 7; break;
+        case 'months': totalDays = loanDurationValue * 30; break;
+        case 'years': totalDays = loanDurationValue * 365; break;
+      }
+
+      const intervalDays = totalDays / numRepayments;
+
+      // Classify into standard frequency codes
+      // Allow ±10% tolerance for matching standard frequencies
+      if (Math.abs(intervalDays - 7) <= 1) {
+        return 'weekly';
+      } else if (Math.abs(intervalDays - 14) <= 2) {
+        return 'biweekly';
+      } else if (Math.abs(intervalDays - 28) <= 2) {
+        return 'every_4_weeks';
+      } else if (Math.abs(intervalDays - 30) <= 3 || Math.abs(intervalDays - 31) <= 3) {
+        return 'monthly';
+      } else if (Math.abs(intervalDays - 91) <= 5) {
+        return 'quarterly';
+      } else if (Math.abs(intervalDays - 365) <= 10) {
+        return 'yearly';
+      } else {
+        // Default to monthly for anything ambiguous
+        return 'monthly';
+      }
+    }
+
 
     function updateFirstPaymentOption() {
       const option = document.getElementById('first-payment-option').value;
@@ -2011,6 +2044,7 @@
       wizardData.firstPaymentDate = firstPaymentDate;
       wizardData.finalDueDate = installmentSchedule[installmentSchedule.length - 1];
       wizardData.installmentSchedule = installmentSchedule;
+      wizardData.paymentFrequency = getPaymentFrequency(loanDurationValue, loanDurationUnit, numRepayments);
 
       // Display summary
       const installmentFormatted = formatEuro2(installmentAmount);
@@ -2331,10 +2365,22 @@
         startDate.setHours(0, 0, 0, 0);
       }
 
-      // Get payment dates from schedule
+      // Generate payment dates using frequency-based calculation with normalization
       let paymentDates = [];
-      if (wizardData.repaymentType === 'installments' && wizardData.installmentSchedule) {
-        paymentDates = wizardData.installmentSchedule.map(dateStr => new Date(dateStr));
+      if (wizardData.repaymentType === 'installments' && wizardData.firstPaymentDate && wizardData.paymentFrequency) {
+        const dateResult = generatePaymentDates({
+          transferDate: startDate,
+          firstDueDate: wizardData.firstPaymentDate,
+          frequency: wizardData.paymentFrequency,
+          count: n
+        });
+        paymentDates = dateResult.paymentDates;
+
+        // Update wizardData with normalized first payment date if it changed
+        if (dateResult.normalizedFirstDueDate.toISOString().split('T')[0] !== wizardData.firstPaymentDate) {
+          wizardData.firstPaymentDate = dateResult.normalizedFirstDueDate.toISOString().split('T')[0];
+          wizardData.finalDueDate = paymentDates[paymentDates.length - 1].toISOString().split('T')[0];
+        }
       } else if (wizardData.repaymentType === 'one_time' && wizardData.dueDate) {
         paymentDates = [new Date(wizardData.dueDate)];
       }
@@ -2680,20 +2726,26 @@
         // Build unified breakdown table using shared schedule utility
         const n = wizardData.repaymentType === 'installments' ? wizardData.installmentCount : 1;
 
-        // Get payment dates
-        let paymentDates = [];
-        if (wizardData.repaymentType === 'installments' && wizardData.installmentSchedule) {
-          paymentDates = wizardData.installmentSchedule.map(dateStr => new Date(dateStr));
-        } else if (wizardData.repaymentType === 'one_time' && wizardData.dueDate) {
-          paymentDates = [new Date(wizardData.dueDate)];
-        }
-
         // Determine start date
         let startDate;
         if (wizardData.moneySentDate && wizardData.moneySentDate !== 'on-acceptance') {
           startDate = new Date(wizardData.moneySentDate);
         } else {
           startDate = new Date();
+        }
+
+        // Generate payment dates using frequency-based calculation with normalization
+        let paymentDates = [];
+        if (wizardData.repaymentType === 'installments' && wizardData.firstPaymentDate && wizardData.paymentFrequency) {
+          const dateResult = generatePaymentDates({
+            transferDate: startDate,
+            firstDueDate: wizardData.firstPaymentDate,
+            frequency: wizardData.paymentFrequency,
+            count: n
+          });
+          paymentDates = dateResult.paymentDates;
+        } else if (wizardData.repaymentType === 'one_time' && wizardData.dueDate) {
+          paymentDates = [new Date(wizardData.dueDate)];
         }
 
         if (paymentDates.length > 0) {
@@ -2921,6 +2973,7 @@
           payload.installmentAmount = wizardData.installmentAmount;
           payload.firstPaymentDate = wizardData.firstPaymentDate;
           payload.finalDueDate = wizardData.finalDueDate;
+          payload.paymentFrequency = wizardData.paymentFrequency;
         }
 
         const res = await fetch('/api/agreements', {

--- a/public/review-details.html
+++ b/public/review-details.html
@@ -1746,35 +1746,30 @@
 
       const n = agreement.repayment_type === 'installments' ? agreement.installment_count : 1;
 
-      // Build payment dates
-      let paymentDates = [];
-      if (agreement.repayment_type === 'installments' && agreement.first_payment_date) {
-        const firstDate = new Date(agreement.first_payment_date);
-        const planUnit = agreement.plan_unit || 'months';
-
-        for (let i = 0; i < n; i++) {
-          const installmentDate = new Date(firstDate);
-          if (planUnit === 'months') {
-            installmentDate.setMonth(installmentDate.getMonth() + i);
-          } else if (planUnit === 'weeks') {
-            installmentDate.setDate(installmentDate.getDate() + (i * 7));
-          } else if (planUnit === 'days') {
-            installmentDate.setDate(installmentDate.getDate() + i);
-          } else if (planUnit === 'years') {
-            installmentDate.setFullYear(installmentDate.getFullYear() + i);
-          }
-          paymentDates.push(installmentDate);
-        }
-      } else if (agreement.repayment_type === 'one_time' && agreement.due_date) {
-        paymentDates.push(new Date(agreement.due_date));
-      }
-
       // Determine start date
       let startDate;
       if (agreement.money_sent_date && agreement.money_sent_date !== 'on-acceptance') {
         startDate = new Date(agreement.money_sent_date);
       } else {
         startDate = agreement.first_payment_date ? new Date(agreement.first_payment_date) : new Date();
+      }
+
+      // Build payment dates using frequency-based calculation
+      let paymentDates = [];
+      if (agreement.repayment_type === 'installments' && agreement.first_payment_date) {
+        // Use frequency from agreement, fallback to 'monthly' if not set
+        const frequency = agreement.payment_frequency || 'monthly';
+
+        // Generate payment dates using frequency-based calculation with normalization
+        const dateResult = generatePaymentDates({
+          transferDate: startDate,
+          firstDueDate: agreement.first_payment_date,
+          frequency: frequency,
+          count: n
+        });
+        paymentDates = dateResult.paymentDates;
+      } else if (agreement.repayment_type === 'one_time' && agreement.due_date) {
+        paymentDates.push(new Date(agreement.due_date));
       }
 
       // Use shared buildRepaymentSchedule function

--- a/public/review.html
+++ b/public/review.html
@@ -517,30 +517,24 @@
       }
       startDate.setHours(0, 0, 0, 0);
 
-      // Build payment dates array
+      // Build payment dates array using frequency-based calculation
       let n = 1;
       let paymentDates = [];
 
       if (agreement.repayment_type === 'installments' && agreement.installment_count) {
         n = agreement.installment_count;
 
-        // Generate evenly-spaced payment dates from first to final
-        const firstDate = new Date(agreement.first_payment_date);
-        const finalDate = new Date(agreement.final_due_date);
-        const totalDurationMs = finalDate - firstDate;
+        // Use frequency from agreement, fallback to 'monthly' if not set
+        const frequency = agreement.payment_frequency || 'monthly';
 
-        for (let i = 0; i < n; i++) {
-          let paymentDate;
-          if (i === 0) {
-            paymentDate = new Date(firstDate);
-          } else if (i === n - 1) {
-            paymentDate = new Date(finalDate);
-          } else {
-            const progressRatio = i / (n - 1);
-            paymentDate = new Date(firstDate.getTime() + (totalDurationMs * progressRatio));
-          }
-          paymentDates.push(paymentDate);
-        }
+        // Generate payment dates using frequency-based calculation with normalization
+        const dateResult = generatePaymentDates({
+          transferDate: startDate,
+          firstDueDate: agreement.first_payment_date,
+          frequency: frequency,
+          count: n
+        });
+        paymentDates = dateResult.paymentDates;
       } else if (agreement.repayment_type === 'one_time' && agreement.due_date) {
         n = 1;
         paymentDates.push(new Date(agreement.due_date));

--- a/server.js
+++ b/server.js
@@ -251,6 +251,11 @@ try {
 } catch (e) {
   // Column already exists, ignore
 }
+try {
+  db.exec(`ALTER TABLE agreements ADD COLUMN payment_frequency TEXT DEFAULT 'monthly';`);
+} catch (e) {
+  // Column already exists, ignore
+}
 
 // --- multer setup for file uploads ---
 const storage = multer.diskStorage({
@@ -803,7 +808,7 @@ app.post('/api/agreements', requireAuth, (req, res) => {
     planLength, planUnit, installmentCount, installmentAmount, firstPaymentDate, finalDueDate,
     interestRate, totalInterest, totalRepayAmount,
     paymentPreferenceMethod, paymentOtherDescription, reminderMode, reminderOffsets,
-    proofRequired, debtCollectionClause, phoneNumber
+    proofRequired, debtCollectionClause, phoneNumber, paymentFrequency
   } = req.body || {};
 
   if (!borrowerEmail || !amount || !dueDate || !description) {
@@ -852,9 +857,9 @@ app.post('/api/agreements', requireAuth, (req, res) => {
         plan_length, plan_unit, installment_count, installment_amount, first_payment_date, final_due_date,
         interest_rate, total_interest, total_repay_amount,
         payment_preference_method, payment_other_description, reminder_mode, reminder_offsets,
-        proof_required, debt_collection_clause
+        proof_required, debt_collection_clause, payment_frequency
       )
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
 
     const agreementInfo = agreementStmt.run(
@@ -883,7 +888,8 @@ app.post('/api/agreements', requireAuth, (req, res) => {
       reminderMode || 'auto',
       reminderOffsets ? JSON.stringify(reminderOffsets) : null,
       proofRequired ? 1 : 0,
-      debtCollectionClause ? 1 : 0
+      debtCollectionClause ? 1 : 0,
+      paymentFrequency || 'monthly'
     );
 
     const agreementId = agreementInfo.lastInsertRowid;

--- a/test/schedule.test.js
+++ b/test/schedule.test.js
@@ -1,0 +1,255 @@
+/**
+ * Unit tests for schedule.js - repayment schedule calculation utilities
+ * Run with: node test/schedule.test.js
+ */
+
+const assert = require('assert');
+const {
+  addMonthsKeepingDay,
+  addOnePeriod,
+  normalizeFirstDueDate,
+  generatePaymentDates,
+  buildRepaymentSchedule
+} = require('../public/js/schedule.js');
+
+// Mock currency formatters for Node.js environment
+global.formatCurrency0 = (cents) => {
+  return new Intl.NumberFormat('nl-NL', { style: 'currency', currency: 'EUR', minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(cents / 100);
+};
+global.formatCurrency2 = (cents) => {
+  return new Intl.NumberFormat('nl-NL', { style: 'currency', currency: 'EUR', minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(cents / 100);
+};
+
+console.log('Running schedule.js unit tests...\n');
+
+// Test 1: normalizeFirstDueDate - same date should shift forward by 1 period
+console.log('Test 1: normalizeFirstDueDate - same date should shift forward');
+{
+  const transferDate = new Date('2025-01-15');
+  const firstDueDate = new Date('2025-01-15');
+  const normalized = normalizeFirstDueDate(transferDate, firstDueDate, 'monthly');
+
+  // Should be Feb 15, 2025
+  assert.strictEqual(normalized.toISOString().split('T')[0], '2025-02-15', 'Monthly shift failed');
+  console.log('✓ Monthly normalization works');
+}
+
+{
+  const transferDate = new Date('2025-01-15');
+  const firstDueDate = new Date('2025-01-15');
+  const normalized = normalizeFirstDueDate(transferDate, firstDueDate, 'every_4_weeks');
+
+  // Should be 28 days later: Feb 12, 2025
+  assert.strictEqual(normalized.toISOString().split('T')[0], '2025-02-12', 'Every 4 weeks shift failed');
+  console.log('✓ Every-4-weeks normalization works');
+}
+
+// Test 2: normalizeFirstDueDate - first due before transfer should also shift
+console.log('\nTest 2: normalizeFirstDueDate - first due before transfer date');
+{
+  const transferDate = new Date('2025-01-20');
+  const firstDueDate = new Date('2025-01-15'); // Before transfer
+  const normalized = normalizeFirstDueDate(transferDate, firstDueDate, 'monthly');
+
+  // Should be Feb 20, 2025
+  assert.strictEqual(normalized.toISOString().split('T')[0], '2025-02-20', 'Should shift from transfer date');
+  console.log('✓ Normalization from transfer date works');
+}
+
+// Test 3: generatePaymentDates - monthly frequency
+console.log('\nTest 3: generatePaymentDates - monthly frequency');
+{
+  const result = generatePaymentDates({
+    transferDate: new Date('2025-01-01'),
+    firstDueDate: new Date('2025-02-01'),
+    frequency: 'monthly',
+    count: 6
+  });
+
+  assert.strictEqual(result.paymentDates.length, 6, 'Should generate 6 dates');
+  assert.strictEqual(result.paymentDates[0].toISOString().split('T')[0], '2025-02-01', 'First date');
+  assert.strictEqual(result.paymentDates[1].toISOString().split('T')[0], '2025-03-01', 'Second date');
+  assert.strictEqual(result.paymentDates[5].toISOString().split('T')[0], '2025-07-01', 'Sixth date');
+  console.log('✓ Monthly payment dates generated correctly');
+}
+
+// Test 4: generatePaymentDates - every_4_weeks frequency
+console.log('\nTest 4: generatePaymentDates - every_4_weeks frequency');
+{
+  const result = generatePaymentDates({
+    transferDate: new Date('2025-01-01'),
+    firstDueDate: new Date('2025-02-01'),
+    frequency: 'every_4_weeks',
+    count: 3
+  });
+
+  assert.strictEqual(result.paymentDates.length, 3, 'Should generate 3 dates');
+  assert.strictEqual(result.paymentDates[0].toISOString().split('T')[0], '2025-02-01', 'First date');
+  assert.strictEqual(result.paymentDates[1].toISOString().split('T')[0], '2025-03-01', 'Second date (28 days later)');
+  assert.strictEqual(result.paymentDates[2].toISOString().split('T')[0], '2025-03-29', 'Third date (56 days later)');
+  console.log('✓ Every-4-weeks payment dates generated correctly');
+}
+
+// Test 5: buildRepaymentSchedule - first row should have interest > 0
+console.log('\nTest 5: buildRepaymentSchedule - first row interest > 0');
+{
+  const transferDate = new Date('2025-01-01');
+  const firstDueDate = new Date('2025-02-01'); // 31 days later
+
+  const schedule = buildRepaymentSchedule({
+    principalCents: 400000, // €4,000
+    aprPercent: 5,
+    count: 6,
+    paymentDates: [
+      new Date('2025-02-01'),
+      new Date('2025-03-01'),
+      new Date('2025-04-01'),
+      new Date('2025-05-01'),
+      new Date('2025-06-01'),
+      new Date('2025-07-01')
+    ],
+    startDate: transferDate
+  });
+
+  assert.strictEqual(schedule.rows.length, 6, 'Should have 6 rows');
+  assert.ok(schedule.rows[0].interestCents > 0, 'First row interest should be > 0');
+
+  // For €4,000 at 5% APR over 31 days: 4000 * (0.05/365) * 31 ≈ €16.99
+  const expectedFirstInterest = Math.round(4000 * (0.05/365) * 31 * 100); // in cents
+  const actualFirstInterest = schedule.rows[0].interestCents;
+
+  // Allow small rounding difference (within 1 cent)
+  assert.ok(Math.abs(actualFirstInterest - expectedFirstInterest) <= 1,
+    `First interest should be ≈ ${expectedFirstInterest} cents, got ${actualFirstInterest}`);
+
+  console.log(`✓ First row interest = €${(actualFirstInterest/100).toFixed(2)} (expected ≈ €${(expectedFirstInterest/100).toFixed(2)})`);
+}
+
+// Test 6: buildRepaymentSchedule - totals should match
+console.log('\nTest 6: buildRepaymentSchedule - totals validation');
+{
+  const schedule = buildRepaymentSchedule({
+    principalCents: 400000, // €4,000
+    aprPercent: 5,
+    count: 6,
+    paymentDates: [
+      new Date('2025-02-01'),
+      new Date('2025-03-01'),
+      new Date('2025-04-01'),
+      new Date('2025-05-01'),
+      new Date('2025-06-01'),
+      new Date('2025-07-01')
+    ],
+    startDate: new Date('2025-01-01')
+  });
+
+  // Sum all principal payments (allow 2 cents rounding tolerance)
+  const totalPrincipal = schedule.rows.reduce((sum, row) => sum + row.principalCents, 0);
+  assert.ok(Math.abs(totalPrincipal - 400000) <= 2, 'Total principal should equal loan amount (within 2 cents)');
+  console.log('✓ Total principal matches loan amount');
+
+  // Sum all interest payments should match totalInterestCents
+  const totalInterest = schedule.rows.reduce((sum, row) => sum + row.interestCents, 0);
+  assert.strictEqual(totalInterest, schedule.totalInterestCents, 'Sum of interest should match total');
+  console.log('✓ Sum of interest matches total');
+
+  // Last row remaining should be 0
+  assert.strictEqual(schedule.rows[5].remainingCents, 0, 'Last row remaining should be 0');
+  console.log('✓ Last row remaining = 0');
+
+  // Total to repay = principal + interest
+  assert.strictEqual(schedule.totalToRepayCents, 400000 + totalInterest, 'Total to repay = principal + interest');
+  console.log('✓ Total to repay = principal + interest');
+}
+
+// Test 7: Edge case - first due date equals transfer date (should be normalized)
+console.log('\nTest 7: Edge case - first due date equals transfer date');
+{
+  const transferDate = new Date('2025-01-15');
+  const firstDueDate = new Date('2025-01-15'); // SAME DATE
+
+  const result = generatePaymentDates({
+    transferDate,
+    firstDueDate,
+    frequency: 'monthly',
+    count: 3
+  });
+
+  // Should normalize to Feb 15
+  assert.strictEqual(result.normalizedFirstDueDate.toISOString().split('T')[0], '2025-02-15',
+    'First due date should be normalized to next month');
+
+  // Build schedule with normalized dates
+  const schedule = buildRepaymentSchedule({
+    principalCents: 100000,
+    aprPercent: 5,
+    count: 3,
+    paymentDates: result.paymentDates,
+    startDate: transferDate
+  });
+
+  // First row should have ~31 days of interest
+  assert.ok(schedule.rows[0].interestCents > 0, 'First row must have interest');
+  console.log(`✓ Normalized first due date; first interest = €${(schedule.rows[0].interestCents/100).toFixed(2)}`);
+}
+
+// Test 8: Monthly vs every_4_weeks - different date series but similar totals
+console.log('\nTest 8: Monthly vs every_4_weeks - compare totals');
+{
+  const transferDate = new Date('2025-01-01');
+  const count = 6;
+
+  // Monthly
+  const monthlyDates = generatePaymentDates({
+    transferDate,
+    firstDueDate: new Date('2025-02-01'),
+    frequency: 'monthly',
+    count
+  });
+
+  const monthlySchedule = buildRepaymentSchedule({
+    principalCents: 400000,
+    aprPercent: 5,
+    count,
+    paymentDates: monthlyDates.paymentDates,
+    startDate: transferDate
+  });
+
+  // Every 4 weeks
+  const every4WeeksDates = generatePaymentDates({
+    transferDate,
+    firstDueDate: new Date('2025-01-29'),
+    frequency: 'every_4_weeks',
+    count
+  });
+
+  const every4WeeksSchedule = buildRepaymentSchedule({
+    principalCents: 400000,
+    aprPercent: 5,
+    count,
+    paymentDates: every4WeeksDates.paymentDates,
+    startDate: transferDate
+  });
+
+  // Dates should be different
+  assert.notStrictEqual(
+    monthlyDates.paymentDates[1].toISOString(),
+    every4WeeksDates.paymentDates[1].toISOString(),
+    'Date series should differ'
+  );
+
+  // Totals will differ because the payment periods are different
+  // Monthly typically has longer periods (30-31 days) vs every-4-weeks (28 days)
+  const monthlyTotal = monthlySchedule.totalInterestCents;
+  const every4WeeksTotal = every4WeeksSchedule.totalInterestCents;
+
+  // Just verify both have reasonable totals (not zero, not absurdly high)
+  assert.ok(monthlyTotal > 0, 'Monthly total should be > 0');
+  assert.ok(every4WeeksTotal > 0, 'Every-4-weeks total should be > 0');
+  assert.ok(monthlyTotal < 50000, 'Monthly total should be reasonable'); // Less than €500 for €4k loan
+  assert.ok(every4WeeksTotal < 50000, 'Every-4-weeks total should be reasonable');
+
+  console.log(`✓ Monthly total: €${(monthlyTotal/100).toFixed(2)}, Every-4-weeks: €${(every4WeeksTotal/100).toFixed(2)}`);
+}
+
+console.log('\n✓ All tests passed!\n');


### PR DESCRIPTION
… unify frequency & schedule across pages

**Problem:**
- Step 3 (wizard) showed first-row interest correctly (e.g., € 16,44 for € 4.000 at 5% monthly)
- Review/Manage pages showed first-row interest = € 0,00 (incorrect)
- Root cause: Some pages allowed first due date == money transfer date, yielding zero-length first period
- Additional issue: Date drift between pages (Step 3 showed "every 4 weeks" but Review/Manage showed "monthly")

**Business Rules Enforced:**
1. Interest accrues from money transfer date to next due date using ACT/365 (actual days / 365)
2. If first due date ≤ transfer date, auto-shift forward by exactly 1 period (respecting frequency)
3. Frequency parity: Use agreement's stored frequency consistently across all pages
4. Single source of truth: All pages use same schedule builder and accordion component

**Implementation:**
- Enhanced `public/js/schedule.js`:
  - Added `addOnePeriod(date, frequency)` - adds exactly 1 period based on frequency
  - Added `normalizeFirstDueDate(transferDate, firstDueDate, frequency)` - ensures first due > transfer
  - Added `generatePaymentDates(...)` - generates dates by frequency (not linear interpolation)
  - Updated exports to support new functions

- Added `payment_frequency` field to database schema:
  - Values: "weekly", "biweekly", "every_4_weeks", "monthly", "quarterly", "yearly"
  - Default: "monthly"

- Updated wizard (public/app.html):
  - Added `getPaymentFrequency()` to classify interval into standard frequency codes
  - Step 2: Calculate and store `paymentFrequency` in wizardData
  - Step 3: Use `generatePaymentDates()` with normalization instead of linear interpolation
  - Step 5: Use same unified schedule builder as Step 3
  - Submit: Include `paymentFrequency` in API payload

- Updated Review page (public/review.html):
  - Replace evenly-spaced date generation with `generatePaymentDates()`
  - Use `payment_frequency` from agreement (fallback to "monthly")

- Updated Manage page (public/review-details.html):
  - Replace buggy plan_unit-based date generation with `generatePaymentDates()`
  - Use `payment_frequency` from agreement (fallback to "monthly")

- Updated server (server.js):
  - Add `payment_frequency` column to agreements table
  - Include `paymentFrequency` in POST /api/agreements endpoint

**Tests:**
- Added comprehensive unit tests (test/schedule.test.js):
  - First due date normalization (same date → +1 period)
  - Monthly vs every_4_weeks date generation
  - First-row interest > 0 validation
  - Totals validation: sum(principal) = principal, last remaining = 0
  - Edge case: first due date equals transfer date

**Acceptance Criteria Met:**
✓ /review and /manage show same first-row interest as Step 3 for same agreement ✓ All pages show identical due dates for same frequency ✓ No page shows first-row interest = € 0,00
✓ Columns/order and two-decimal formatting identical everywhere ✓ Frequency-based date generation replaces linear interpolation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic payment frequency detection and calculation (weekly, biweekly, monthly, quarterly, yearly).
  * Improved payment date generation to ensure consistency based on detected frequency.
  * Payment frequency is now tracked and stored with loan agreements.

* **Tests**
  * Added comprehensive test coverage for payment date calculations and schedule generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->