### PR TITLE
Remove My Agreements from manage/review; add unified top bar

### DIFF
--- a/public/components/page-topbar.js
+++ b/public/components/page-topbar.js
@@ -1,0 +1,84 @@
+/**
+ * Unified Top Bar Component
+ * For manage and review pages - shows title, subtitle, and return button
+ */
+
+/**
+ * Renders a page top bar with title, subtitle, and return button
+ * @param {Object} options
+ * @param {string} options.title - Main title (e.g., "Manage agreement")
+ * @param {string} [options.subtitle] - Optional subtitle (e.g., "For new bicycle — Bob")
+ * @param {string} [options.href="/app"] - Return link destination
+ * @returns {HTMLElement} The top bar container element
+ */
+export function renderPageTopbar({ title, subtitle, href = "/app" }) {
+  const container = document.createElement("div");
+  container.className = "page-topbar-container";
+  container.style.cssText = "display: flex; align-items: center; justify-content: space-between; padding: 24px 0; margin-bottom: 16px;";
+
+  // Left side: Title and subtitle
+  const left = document.createElement("div");
+  left.style.cssText = "flex: 1;";
+
+  const titleEl = document.createElement("h1");
+  titleEl.textContent = title;
+  titleEl.style.cssText = "margin: 0 0 8px 0; font-size: 24px; font-weight: 600; color: var(--text);";
+  left.appendChild(titleEl);
+
+  if (subtitle) {
+    const subtitleEl = document.createElement("div");
+    subtitleEl.textContent = subtitle;
+    subtitleEl.style.cssText = "margin: 0; font-size: 16px; color: var(--muted);";
+    left.appendChild(subtitleEl);
+  }
+
+  // Right side: Return button
+  const right = document.createElement("a");
+  right.href = href;
+  right.className = "return-button";
+  right.style.cssText = `
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 0 16px;
+    height: 40px;
+    border-radius: 10px;
+    background: var(--accent);
+    color: #0d130f;
+    font-weight: 700;
+    text-decoration: none;
+    transition: filter 0.2s ease;
+    border: none;
+  `;
+
+  // Arrow icon (left arrow)
+  const icon = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  icon.setAttribute("width", "16");
+  icon.setAttribute("height", "16");
+  icon.setAttribute("viewBox", "0 0 24 24");
+  icon.setAttribute("fill", "currentColor");
+  icon.style.cssText = "flex-shrink: 0;";
+
+  const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+  path.setAttribute("d", "M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z");
+  icon.appendChild(path);
+
+  const text = document.createElement("span");
+  text.textContent = "Return to My agreements";
+
+  right.appendChild(icon);
+  right.appendChild(text);
+
+  // Hover effect
+  right.addEventListener("mouseenter", () => {
+    right.style.filter = "brightness(1.06)";
+  });
+  right.addEventListener("mouseleave", () => {
+    right.style.filter = "brightness(1)";
+  });
+
+  container.appendChild(left);
+  container.appendChild(right);
+
+  return container;
+}

--- a/public/review-details.html
+++ b/public/review-details.html
@@ -175,6 +175,9 @@
   <div class="container">
     <!-- Header will be loaded dynamically by header.js -->
 
+    <!-- Page top bar (for manage/view mode) -->
+    <div id="page-topbar-container"></div>
+
     <!-- My Agreements section -->
     <section class="card" id="list-section">
       <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:16px">
@@ -217,10 +220,9 @@
       <p id="loading-text">Loading agreement details...</p>
     </div>
 
-    <!-- Manage agreement header (for view mode) -->
+    <!-- Manage agreement header (for view mode) - now using page-topbar component -->
     <div id="manage-header" class="hidden" style="margin:16px 0 24px 0">
-      <h2 style="margin:0 0 8px 0; font-size:24px">Manage agreement</h2>
-      <p id="manage-subline" style="margin:8px 0 0 0; font-size:16px; color:var(--muted)"></p>
+      <!-- Top bar will be rendered here dynamically -->
     </div>
 
     <!-- Agreement summary block (above details card) -->
@@ -625,9 +627,33 @@
       }
     }
 
-    function showReviewSection() {
+    async function showReviewSection() {
       document.getElementById('loading-card').classList.add('hidden');
       document.getElementById('details-section').classList.remove('hidden');
+
+      // Hide My Agreements section when in review mode
+      document.getElementById('list-section').classList.add('hidden');
+
+      // Show top bar for review mode
+      const description = agreement.description || 'Agreement';
+
+      // Dynamically import and render the top bar
+      try {
+        const { renderPageTopbar } = await import('/components/page-topbar.js');
+        const topbar = renderPageTopbar({
+          title: 'Review agreement',
+          subtitle: description,
+          href: '/app'
+        });
+
+        // Clear and append the top bar
+        const manageHeader = document.getElementById('manage-header');
+        manageHeader.innerHTML = '';
+        manageHeader.appendChild(topbar);
+        manageHeader.classList.remove('hidden');
+      } catch (err) {
+        console.error('Error loading top bar component:', err);
+      }
 
       populateDetails();
 
@@ -657,11 +683,33 @@
       document.getElementById('loading-card').classList.add('hidden');
       document.getElementById('details-section').classList.remove('hidden');
 
-      // Show and populate manage header
+      // Hide My Agreements section when viewing a specific agreement
+      document.getElementById('list-section').classList.add('hidden');
+
+      // Show and populate manage header with new top bar component
       const borrowerName = agreement.borrower_full_name || agreement.friend_first_name || agreement.borrower_email;
       const description = agreement.description || 'Agreement';
-      document.getElementById('manage-subline').textContent = `${description} – ${borrowerName}`;
-      document.getElementById('manage-header').classList.remove('hidden');
+
+      // Dynamically import and render the top bar
+      try {
+        const { renderPageTopbar } = await import('/components/page-topbar.js');
+        const topbar = renderPageTopbar({
+          title: 'Manage agreement',
+          subtitle: `${description} — ${borrowerName}`,
+          href: '/app'
+        });
+
+        // Clear and append the top bar
+        const manageHeader = document.getElementById('manage-header');
+        manageHeader.innerHTML = '';
+        manageHeader.appendChild(topbar);
+        manageHeader.classList.remove('hidden');
+      } catch (err) {
+        console.error('Error loading top bar component:', err);
+        // Fallback to old header if import fails
+        document.getElementById('manage-subline').textContent = `${description} – ${borrowerName}`;
+        document.getElementById('manage-header').classList.remove('hidden');
+      }
 
       populateDetails();
 


### PR DESCRIPTION
…r with Return button (no border)

- Created reusable page-topbar.js component with unified top bar
- Top bar includes:
  - Title and subtitle on left
  - Green "Return to My agreements" button with arrow icon on right (no border)
- Manage page (/agreements/:id/manage):
  - Hides "My Agreements" table
  - Shows top bar with "Manage agreement" title
  - Subtitle shows description + borrower name
- Review page (/agreements/:id/review):
  - Hides "My Agreements" table
  - Shows top bar with "Review agreement" title
  - Subtitle shows description only
- Dashboard (/app) remains unchanged with My Agreements table visible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified top bar across manage and review pages displaying the page title and descriptive subtitle
  * Implemented a styled "Return to My agreements" navigation button with arrow icon and hover effects for seamless navigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->