### PR TITLE
Fix Step 5 summary field order and dropdown titles

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -13,6 +13,8 @@
   <script src="/js/phone-input.js"></script>
   <!-- Centralized currency formatters -->
   <script src="/js/formatters.js"></script>
+  <!-- Summary block component -->
+  <script src="/components/summary-block.js"></script>
   <style>
     :root{
       --bg:#0e1116; --card:#151a21; --text:#e6eef6; --muted:#a7b0bd; --accent:#3ddc97;
@@ -888,10 +890,10 @@
           </div>
         </div>
 
-        <!-- Expandable: Interest, payment calculation & installment schedule -->
+        <!-- Expandable: Repayment schedule & interest calculation -->
         <div style="margin:16px 0">
           <button onclick="toggleSection('interest-calc-section')" class="secondary" style="width:100%; text-align:left; padding:12px 16px; font-size:14px; display:flex; justify-content:space-between; align-items:center">
-            <span>Interest, payment calculation & installment schedule</span>
+            <span>Repayment schedule & interest calculation</span>
             <span id="interest-calc-toggle">▼</span>
           </button>
           <div id="interest-calc-section" class="hidden" style="background:#10151d; border:1px solid rgba(255,255,255,0.08); border-radius:0 0 8px 8px; padding:16px; margin-top:-1px">
@@ -899,10 +901,10 @@
           </div>
         </div>
 
-        <!-- Expandable: Payments & Reminders -->
+        <!-- Expandable: Repayment details & reminders -->
         <div style="margin:16px 0">
           <button onclick="toggleSection('payments-reminders-section')" class="secondary" style="width:100%; text-align:left; padding:12px 16px; font-size:14px; display:flex; justify-content:space-between; align-items:center">
-            <span>Payments & reminders</span>
+            <span>Repayment details & reminders</span>
             <span id="payments-reminders-toggle">▼</span>
           </button>
           <div id="payments-reminders-section" class="hidden" style="background:#10151d; border:1px solid rgba(255,255,255,0.08); border-radius:0 0 8px 8px; padding:16px; margin-top:-1px">
@@ -2605,106 +2607,10 @@
       populatePaymentsAndReminders();
     }
 
-    // Populate general details section
+    // Populate general details section using deterministic renderer
     function populateGeneralDetails() {
       const content = document.getElementById('general-details-content');
-      const lenderName = currentUser?.full_name || currentUser?.email || 'You';
-
-      let html = '<div class="summary-grid">';
-
-      html += `<div class="summary-grid-row" style="padding:8px 0; border-bottom:1px solid rgba(255,255,255,0.05)">
-        <span class="summary-grid-label">Description</span>
-        <span class="summary-grid-value" style="font-weight:600">${wizardData.description}</span>
-      </div>`;
-
-      html += `<div class="summary-grid-row" style="padding:8px 0; border-bottom:1px solid rgba(255,255,255,0.05)">
-        <span class="summary-grid-label">Lender</span>
-        <span class="summary-grid-value" style="font-weight:600">${lenderName}</span>
-      </div>`;
-
-      html += `<div class="summary-grid-row" style="padding:8px 0; border-bottom:1px solid rgba(255,255,255,0.05)">
-        <span class="summary-grid-label">Borrower</span>
-        <span class="summary-grid-value" style="font-weight:600">${wizardData.friendFirstName}</span>
-      </div>`;
-
-      html += `<div class="summary-grid-row" style="padding:8px 0; border-bottom:1px solid rgba(255,255,255,0.05)">
-        <span class="summary-grid-label">Borrower email</span>
-        <span class="summary-grid-value" style="font-weight:600">${wizardData.friendEmail}</span>
-      </div>`;
-
-      html += `<div class="summary-grid-row" style="padding:8px 0; border-bottom:1px solid rgba(255,255,255,0.05)">
-        <span class="summary-grid-label">Amount</span>
-        <span class="summary-grid-value" style="font-weight:600">${formatCurrency2(Math.round(wizardData.amount * 100))}</span>
-      </div>`;
-
-      let moneySentDateFormatted;
-      if (wizardData.moneySentDate === 'on-acceptance') {
-        moneySentDateFormatted = 'Upon agreement acceptance';
-      } else if (wizardData.moneySentOption) {
-        // Show friendly text for relative dates
-        const option = wizardData.moneySentOption;
-        if (option === 'today') moneySentDateFormatted = 'Today';
-        else if (option === 'tomorrow') moneySentDateFormatted = 'Tomorrow';
-        else if (option === '3days') moneySentDateFormatted = 'In 3 days';
-        else if (option === '7days') moneySentDateFormatted = 'In 7 days';
-        else moneySentDateFormatted = new Date(wizardData.moneySentDate).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
-      } else {
-        moneySentDateFormatted = new Date(wizardData.moneySentDate).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
-      }
-      html += `<div class="summary-grid-row" style="padding:8px 0; border-bottom:1px solid rgba(255,255,255,0.05)">
-        <span class="summary-grid-label">Money transfer date</span>
-        <span class="summary-grid-value" style="font-weight:600">${moneySentDateFormatted}</span>
-      </div>`;
-
-      html += `<div class="summary-grid-row" style="padding:8px 0; border-bottom:1px solid rgba(255,255,255,0.05)">
-        <span class="summary-grid-label">Repayment type</span>
-        <span class="summary-grid-value" style="font-weight:600">${wizardData.repaymentType === 'one_time' ? 'One-time payment' : 'Installments'}</span>
-      </div>`;
-
-      if (wizardData.repaymentType === 'installments') {
-        const intervalText = getIntervalText(wizardData.loanDurationValue, wizardData.loanDurationUnit, wizardData.numRepayments || wizardData.installmentCount);
-
-        const durationText = wizardData.planUnit === 'days' ? `${wizardData.planLength} ${wizardData.planLength === 1 ? 'day' : 'days'}` :
-                             wizardData.planUnit === 'weeks' ? `${wizardData.planLength} ${wizardData.planLength === 1 ? 'week' : 'weeks'}` :
-                             wizardData.planUnit === 'months' ? `${wizardData.planLength} ${wizardData.planLength === 1 ? 'month' : 'months'}` :
-                             wizardData.planUnit === 'years' ? `${wizardData.planLength} ${wizardData.planLength === 1 ? 'year' : 'years'}` :
-                             `${wizardData.planLength} months`;
-
-        html += `<div class="summary-grid-row" style="padding:8px 0; border-bottom:1px solid rgba(255,255,255,0.05)">
-          <span class="summary-grid-label">Loan duration</span>
-          <span class="summary-grid-value" style="font-weight:600">${durationText}</span>
-        </div>`;
-
-        html += `<div class="summary-grid-row" style="padding:8px 0; border-bottom:1px solid rgba(255,255,255,0.05)">
-          <span class="summary-grid-label">Number of repayments</span>
-          <span class="summary-grid-value" style="font-weight:600">${wizardData.numRepayments || wizardData.installmentCount}</span>
-        </div>`;
-
-        html += `<div class="summary-grid-row" style="padding:8px 0; border-bottom:1px solid rgba(255,255,255,0.05)">
-          <span class="summary-grid-label">Repayment interval</span>
-          <span class="summary-grid-value" style="font-weight:600">${intervalText}</span>
-        </div>`;
-
-        const firstDate = new Date(wizardData.firstPaymentDate).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
-        html += `<div class="summary-grid-row" style="padding:8px 0; border-bottom:1px solid rgba(255,255,255,0.05)">
-          <span class="summary-grid-label">First payment date</span>
-          <span class="summary-grid-value" style="font-weight:600">${firstDate}</span>
-        </div>`;
-
-        const finalDate = new Date(wizardData.finalDueDate).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
-        html += `<div class="summary-grid-row" style="padding:8px 0; border-bottom:1px solid rgba(255,255,255,0.05)">
-          <span class="summary-grid-label">Final due date</span>
-          <span class="summary-grid-value" style="font-weight:600">${finalDate}</span>
-        </div>`;
-      } else {
-        const dueDate = new Date(wizardData.dueDate).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
-        html += `<div class="summary-grid-row" style="padding:8px 0; border-bottom:1px solid rgba(255,255,255,0.05)">
-          <span class="summary-grid-label">Due date</span>
-          <span class="summary-grid-value" style="font-weight:600">${dueDate}</span>
-        </div>`;
-      }
-
-      html += '</div>';
+      const html = renderSummaryFields(wizardData, currentUser);
       content.innerHTML = html;
     }
 

--- a/public/components/summary-block.js
+++ b/public/components/summary-block.js
@@ -1,0 +1,253 @@
+/**
+ * Summary Block Component
+ * Provides deterministic rendering of agreement summary fields in Step 5
+ * with exact field ordering for installment vs one-time loans
+ */
+
+/**
+ * Summary item types:
+ * - field: A label-value pair
+ * - spacer: A blank line for visual spacing
+ * - dropdown: Reference to an expandable section
+ */
+
+/**
+ * Exact field order for INSTALLMENT loans
+ */
+const SUMMARY_ORDER_INSTALLMENTS = [
+  // Section 1: Basic info
+  { kind: "field", label: "Loan description", key: "description" },
+  { kind: "field", label: "Lender name", key: "lenderName" },
+  { kind: "field", label: "Borrower name", key: "borrowerName" },
+  { kind: "field", label: "Borrower email", key: "borrowerEmail" },
+  { kind: "field", label: "Borrower phone", key: "borrowerPhone" },
+
+  { kind: "spacer" },
+
+  // Section 2: Loan terms
+  { kind: "field", label: "Money transfer date (loan start date)", key: "moneyTransferDate" },
+  { kind: "field", label: "Amount", key: "amount" },
+  { kind: "field", label: "Repayment type", key: "repaymentType" },
+  { kind: "field", label: "Loan duration", key: "loanDuration" },
+  { kind: "field", label: "Interest rate", key: "interestRate" },
+  { kind: "field", label: "Total interest", key: "totalInterest" },
+  { kind: "field", label: "Total to repay", key: "totalToRepay" },
+
+  { kind: "spacer" },
+
+  // Section 3: Installment details
+  { kind: "field", label: "Number of payment installments", key: "numberOfInstallments" },
+  { kind: "field", label: "Payment frequency", key: "paymentFrequency" },
+  { kind: "field", label: "First repayment date", key: "firstRepaymentDate" },
+  { kind: "field", label: "Final due date", key: "finalDueDate" },
+
+  { kind: "spacer" },
+
+  // Section 4: Payment details
+  { kind: "field", label: "Repayment method(s)", key: "repaymentMethods" },
+  { kind: "field", label: "Require proof of payment", key: "requireProof", hideIfEmpty: true },
+  { kind: "field", label: "Reminders", key: "reminders" },
+  { kind: "field", label: "Worst case scenario plan", key: "worstCase", hideIfEmpty: true },
+
+  { kind: "spacer" },
+
+  // Dropdowns
+  { kind: "dropdown", from: "interest", title: "Repayment schedule & interest calculation" },
+  { kind: "dropdown", from: "payments", title: "Repayment details & reminders" },
+  { kind: "dropdown", from: "share", title: "Sharing details" }
+];
+
+/**
+ * Exact field order for ONE-TIME loans
+ */
+const SUMMARY_ORDER_ONETIME = [
+  // Section 1: Basic info
+  { kind: "field", label: "Loan description", key: "description" },
+  { kind: "field", label: "Lender name", key: "lenderName" },
+  { kind: "field", label: "Borrower name", key: "borrowerName" },
+  { kind: "field", label: "Borrower email", key: "borrowerEmail" },
+  { kind: "field", label: "Borrower phone", key: "borrowerPhone" },
+
+  { kind: "spacer" },
+
+  // Section 2: Loan terms (one-time specific)
+  { kind: "field", label: "Money transfer date (loan start date)", key: "moneyTransferDate" },
+  { kind: "field", label: "Amount", key: "amount" },
+  { kind: "field", label: "Repayment type", key: "repaymentType" },
+  { kind: "field", label: "Loan duration", key: "loanDuration" },
+  { kind: "field", label: "Full repayment due date", key: "fullRepaymentDueDate" },
+  { kind: "field", label: "Interest rate", key: "interestRate" },
+  { kind: "field", label: "Total interest", key: "totalInterest" },
+  { kind: "field", label: "Total to repay", key: "totalToRepay" },
+
+  { kind: "spacer" },
+
+  // Section 3: Payment details
+  { kind: "field", label: "Repayment method(s)", key: "repaymentMethods" },
+  { kind: "field", label: "Require proof of payment", key: "requireProof", hideIfEmpty: true },
+  { kind: "field", label: "Reminders", key: "reminders" },
+  { kind: "field", label: "Worst case scenario plan", key: "worstCase", hideIfEmpty: true },
+
+  { kind: "spacer" },
+
+  // Dropdowns
+  { kind: "dropdown", from: "interest", title: "Repayment schedule & interest calculation" },
+  { kind: "dropdown", from: "payments", title: "Repayment details & reminders" },
+  { kind: "dropdown", from: "share", title: "Sharing details" }
+];
+
+/**
+ * Build data map from wizard data
+ * @param {Object} wizardData - The wizard data object
+ * @param {Object} currentUser - The current user object
+ * @returns {Object} Map of keys to formatted values
+ */
+function buildSummaryDataMap(wizardData, currentUser) {
+  const lenderName = currentUser?.full_name || currentUser?.email || 'You';
+
+  // Format money transfer date
+  let moneyTransferDate;
+  if (wizardData.moneySentDate === 'on-acceptance') {
+    moneyTransferDate = 'Upon agreement acceptance';
+  } else if (wizardData.moneySentOption) {
+    const option = wizardData.moneySentOption;
+    if (option === 'today') moneyTransferDate = 'Today';
+    else if (option === 'tomorrow') moneyTransferDate = 'Tomorrow';
+    else if (option === '3days') moneyTransferDate = 'In 3 days';
+    else if (option === '7days') moneyTransferDate = 'In 7 days';
+    else moneyTransferDate = new Date(wizardData.moneySentDate).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
+  } else {
+    moneyTransferDate = new Date(wizardData.moneySentDate).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
+  }
+
+  // Format loan duration
+  const durationText = wizardData.planUnit === 'days' ? `${wizardData.planLength} ${wizardData.planLength === 1 ? 'day' : 'days'}` :
+                       wizardData.planUnit === 'weeks' ? `${wizardData.planLength} ${wizardData.planLength === 1 ? 'week' : 'weeks'}` :
+                       wizardData.planUnit === 'months' ? `${wizardData.planLength} ${wizardData.planLength === 1 ? 'month' : 'months'}` :
+                       wizardData.planUnit === 'years' ? `${wizardData.planLength} ${wizardData.planLength === 1 ? 'year' : 'years'}` :
+                       `${wizardData.planLength} months`;
+
+  // Format payment frequency
+  let paymentFrequency = '';
+  if (wizardData.paymentFrequency) {
+    const freq = wizardData.paymentFrequency;
+    if (freq === 'weekly') paymentFrequency = 'Weekly';
+    else if (freq === 'biweekly') paymentFrequency = 'Every 2 weeks';
+    else if (freq === 'monthly') paymentFrequency = 'Monthly';
+    else if (freq === 'quarterly') paymentFrequency = 'Every 3 months';
+    else if (freq === 'yearly') paymentFrequency = 'Yearly';
+    else if (freq.startsWith('every_')) {
+      const days = freq.replace('every_', '').replace('_days', '');
+      paymentFrequency = `Every ${days} days`;
+    } else {
+      paymentFrequency = freq;
+    }
+  }
+
+  // Format payment methods
+  const methods = wizardData.paymentMethods || [];
+  const methodLabels = methods.map(m => {
+    if (m === 'bank') return 'Bank transfer';
+    if (m === 'cash') return 'Cash in person';
+    if (m === 'crypto') return 'Crypto';
+    if (m === 'any') return 'Any method';
+    if (m === 'other') return `Other${wizardData.paymentOtherDescription ? ': ' + wizardData.paymentOtherDescription : ''}`;
+    return m;
+  });
+  const methodsText = methodLabels.length > 0 ? methodLabels.join(', ') : 'Not specified';
+
+  // Format reminders
+  let remindersText = '';
+  if (wizardData.reminderMode === 'auto') {
+    remindersText = 'Auto reminders (7 days before, 1 day before, on due date; if unpaid: 1 day after, then every 3 days)';
+  } else if (wizardData.reminderOffsets && wizardData.reminderOffsets.length > 0) {
+    const reminderList = wizardData.reminderOffsets.sort((a, b) => a - b).map(offset => {
+      if (offset < 0) return `${Math.abs(offset)} days before`;
+      if (offset === 0) return 'On due date';
+      if (offset === 3) return 'Every 3 days after';
+      if (offset === 7) return 'Every 7 days after';
+      return `${offset} day${offset > 1 ? 's' : ''} after`;
+    });
+    remindersText = 'Custom: ' + reminderList.join(', ');
+  } else {
+    remindersText = 'Not configured';
+  }
+
+  // Format phone number
+  const phoneNumber = wizardData.phoneNumber || '';
+
+  return {
+    description: wizardData.description,
+    lenderName: lenderName,
+    borrowerName: wizardData.friendFirstName,
+    borrowerEmail: wizardData.friendEmail,
+    borrowerPhone: phoneNumber,
+    moneyTransferDate: moneyTransferDate,
+    amount: formatCurrency2(Math.round(wizardData.amount * 100)),
+    repaymentType: wizardData.repaymentType === 'one_time' ? 'One-time payment' : 'Installments',
+    loanDuration: durationText,
+    interestRate: wizardData.interestRate > 0 ? `${wizardData.interestRate}% per year` : '0% (interest-free)',
+    totalInterest: formatCurrency2(Math.round((wizardData.totalInterest || 0) * 100)),
+    totalToRepay: formatCurrency2(Math.round(wizardData.totalRepayAmount * 100)),
+    numberOfInstallments: wizardData.installmentCount || wizardData.numRepayments || '',
+    paymentFrequency: paymentFrequency,
+    firstRepaymentDate: wizardData.firstPaymentDate ? new Date(wizardData.firstPaymentDate).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' }) : '',
+    finalDueDate: wizardData.finalDueDate ? new Date(wizardData.finalDueDate).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' }) : '',
+    fullRepaymentDueDate: wizardData.dueDate ? new Date(wizardData.dueDate).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' }) : '',
+    repaymentMethods: methodsText,
+    requireProof: wizardData.proofRequired ? 'Yes — Borrower must upload proof (photo, screenshot, or PDF) with each payment' : null,
+    reminders: remindersText,
+    worstCase: wizardData.debtCollectionClause ? 'Enabled — If borrower does not repay or propose a new plan, case may be handed to independent debt collector' : null
+  };
+}
+
+/**
+ * Render summary fields in exact order
+ * @param {Object} wizardData - The wizard data object
+ * @param {Object} currentUser - The current user object
+ * @returns {string} HTML string for summary fields
+ */
+function renderSummaryFields(wizardData, currentUser) {
+  const dataMap = buildSummaryDataMap(wizardData, currentUser);
+  const order = wizardData.repaymentType === 'one_time' ? SUMMARY_ORDER_ONETIME : SUMMARY_ORDER_INSTALLMENTS;
+
+  let html = '<div class="summary-grid">';
+  let isFirstField = true;
+
+  for (const item of order) {
+    if (item.kind === 'field') {
+      const value = dataMap[item.key];
+
+      // Skip if hideIfEmpty and value is null/empty
+      if (item.hideIfEmpty && (!value || value === null)) {
+        continue;
+      }
+
+      // Add border to all but first field
+      const borderStyle = isFirstField ? '' : 'border-top:1px solid rgba(255,255,255,0.05);';
+      isFirstField = false;
+
+      html += `<div class="summary-grid-row" style="padding:8px 0;${borderStyle}">
+        <span class="summary-grid-label">${item.label}</span>
+        <span class="summary-grid-value" style="font-weight:600">${value || '—'}</span>
+      </div>`;
+    } else if (item.kind === 'spacer') {
+      // Render blank line as vertical spacing
+      html += '<div style="height:16px"></div>';
+      isFirstField = true; // Reset border for next section
+    }
+  }
+
+  html += '</div>';
+  return html;
+}
+
+/**
+ * Get dropdown configurations from order
+ * @param {string} repaymentType - 'installments' or 'one_time'
+ * @returns {Array} Array of dropdown configs
+ */
+function getSummaryDropdowns(repaymentType) {
+  const order = repaymentType === 'one_time' ? SUMMARY_ORDER_ONETIME : SUMMARY_ORDER_INSTALLMENTS;
+  return order.filter(item => item.kind === 'dropdown');
+}

--- a/public/review-details.html
+++ b/public/review-details.html
@@ -300,10 +300,10 @@
         </div>
       </div>
 
-      <!-- Interest, payment calculation & installment schedule (collapsible) -->
+      <!-- Repayment schedule & interest calculation (collapsible) -->
       <div id="interest-calc-card" class="hidden" style="margin:16px 0">
         <button onclick="toggleReviewSection('interest-calc-detail')" class="secondary" style="width:100%; text-align:left; padding:12px 16px; font-size:14px; display:flex; justify-content:space-between; align-items:center">
-          <span>Interest, payment calculation & installment schedule</span>
+          <span>Repayment schedule & interest calculation</span>
           <span id="interest-calc-detail-toggle">▼</span>
         </button>
         <div id="interest-calc-detail" class="hidden" style="background:#10151d; border:1px solid rgba(255,255,255,0.08); border-radius:0 0 8px 8px; padding:16px; margin-top:-1px">
@@ -311,10 +311,10 @@
         </div>
       </div>
 
-      <!-- Payments & reminders (collapsible) -->
+      <!-- Repayment details & reminders (collapsible) -->
       <div id="payments-reminders-card" class="hidden" style="margin:16px 0">
         <button onclick="toggleReviewSection('payments-reminders-detail')" class="secondary" style="width:100%; text-align:left; padding:12px 16px; font-size:14px; display:flex; justify-content:space-between; align-items:center">
-          <span>Payments & reminders</span>
+          <span>Repayment details & reminders</span>
           <span id="payments-reminders-detail-toggle">▼</span>
         </button>
         <div id="payments-reminders-detail" class="hidden" style="background:#10151d; border:1px solid rgba(255,255,255,0.08); border-radius:0 0 8px 8px; padding:16px; margin-top:-1px">
@@ -322,10 +322,10 @@
         </div>
       </div>
 
-      <!-- Share (collapsible, lender only, for pending agreements) -->
+      <!-- Sharing details (collapsible, lender only, for pending agreements) -->
       <div id="share-card" class="hidden" style="margin:16px 0">
         <button onclick="toggleReviewSection('share-detail')" class="secondary" style="width:100%; text-align:left; padding:12px 16px; font-size:14px; display:flex; justify-content:space-between; align-items:center">
-          <span>Share</span>
+          <span>Sharing details</span>
           <span id="share-detail-toggle">▼</span>
         </button>
         <div id="share-detail" class="hidden" style="background:#10151d; border:1px solid rgba(255,255,255,0.08); border-radius:0 0 8px 8px; padding:16px; margin-top:-1px">


### PR DESCRIPTION
… one-time; preserve blank lines; standardize dropdown titles

- Create summary-block.js component with deterministic field ordering
- Define SUMMARY_ORDER_INSTALLMENTS and SUMMARY_ORDER_ONETIME arrays with exact field sequences
- Add support for spacer items to render blank lines as vertical spacing
- Include borrower phone in summary display
- Update populateGeneralDetails() to use renderSummaryFields() from summary-block.js
- Standardize dropdown titles across app:
  * "Interest, payment calculation & installment schedule" → "Repayment schedule & interest calculation"
  * "Payments & reminders" → "Repayment details & reminders"
  * "Share" → "Sharing details"
- Update Step 5 (app.html) and Review page (review-details.html) with new titles
- Hide optional fields (proof of payment, worst case) when not enabled
- Format all monetary values with 2 decimals (formatCurrency2)
- Maintain exact blank line spacing between field sections per requirements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced agreement summary display with improved field organization and formatting for both installment and one-time loan types.

* **UI Updates**
  * Updated section labels in the review details page for improved clarity, including "Repayment schedule & interest calculation" and "Repayment details & reminders".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->