### PR TITLE
Remove stray Agreement Details banner from Review/Manage

### DIFF
--- a/public/review-details.html
+++ b/public/review-details.html
@@ -219,9 +219,9 @@
       </div>
     </section>
 
-    <div class="card" id="loading-card">
-      <h1 id="page-title">Agreement Details</h1>
-      <p id="loading-text">Loading agreement details...</p>
+    <!-- Loading state moved to page-topbar-container -->
+    <div id="loading-card" style="margin:24px 0">
+      <p id="loading-text" style="color:var(--muted); font-size:14px">Loading...</p>
     </div>
 
     <!-- Manage agreement header (for view mode) - now using page-topbar component -->
@@ -251,10 +251,8 @@
 
     <!-- Agreement details -->
     <div id="details-section" class="card hidden">
-      <h2>Agreement Details</h2>
-
       <!-- Details section -->
-      <div style="margin:16px 0">
+      <div style="margin:0 0 16px 0">
         <div class="detail-row">
           <span class="detail-label">Lender name</span>
           <span class="detail-value" id="lender-name"></span>
@@ -1144,7 +1142,7 @@
       // Hide error section and show loading
       document.getElementById('error-section').classList.add('hidden');
       document.getElementById('loading-card').classList.remove('hidden');
-      document.getElementById('loading-text').textContent = 'Loading agreement details...';
+      document.getElementById('loading-text').textContent = 'Loading...';
       // Retry loading the agreement
       loadAgreementData();
     }

--- a/public/review.html
+++ b/public/review.html
@@ -94,8 +94,7 @@
   <!-- Loading state -->
   <div class="container-narrow">
     <div class="card">
-      <h1>Agreement Review</h1>
-      <p id="loading-text">Loading agreement details...</p>
+      <p id="loading-text" style="color:var(--muted); font-size:14px">Loading...</p>
     </div>
   </div>
 
@@ -131,11 +130,24 @@
 
   <!-- Logged in: show agreement review -->
   <div id="review-section" class="container hidden">
-    <div class="card">
-      <h2>Agreement Details</h2>
+    <!-- Page header with title and return button -->
+    <div style="display:flex; align-items:center; justify-content:space-between; padding:24px 0 16px 0; margin-bottom:8px">
+      <div style="flex:1">
+        <h1 style="margin:0; font-size:24px; font-weight:600; color:var(--text)">Review agreement</h1>
+      </div>
+      <div style="display:flex; align-items:center; gap:16px">
+        <a href="/app" style="display:inline-flex; align-items:center; gap:8px; padding:0 16px; height:40px; border-radius:10px; background:var(--accent); color:#0d130f; font-weight:700; text-decoration:none; transition:filter 0.2s ease; border:none">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" style="flex-shrink:0">
+            <path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"/>
+          </svg>
+          <span>Return to My agreements</span>
+        </a>
+      </div>
+    </div>
 
+    <div class="card">
       <!-- Review summary section -->
-      <section aria-labelledby="review-summary" style="margin:16px 0">
+      <section aria-labelledby="review-summary" style="margin:0 0 16px 0">
         <h3 id="review-summary" style="font-size:16px; font-weight:600; margin:0 0 12px 0; color:var(--text)">Review summary</h3>
         <div style="display:grid; grid-template-columns:1fr; gap:12px">
           <div class="summary-grid-row" style="display:grid; grid-template-columns:1fr 2fr; gap:12px; padding:8px 0">


### PR DESCRIPTION
…nd clean top spacing

- Deleted the legacy banner + "Loading agreement details..." at the top of Review and Manage pages.
- Ensured pages start with "Review agreement" / "Manage agreement" and the Return button.
- Removed unused JS writes to the old header.
- Normalized spacing and kept compact table rows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified loading message and adjusted visual styling with muted color and smaller font size
  * Removed redundant Agreement Details header from initial view
  * Added "Review agreement" header with "Return to My agreements" action button
  * Refined margins and spacing throughout review and details sections for improved layout

<!-- end of auto-generated comment: release notes by coderabbit.ai -->