### PR TITLE
Clean up header spacing and reposition status badge

### DIFF
--- a/public/components/page-topbar.js
+++ b/public/components/page-topbar.js
@@ -17,9 +17,9 @@
 export function renderPageTopbar({ title, subtitle, href = "/app", statusBadge }) {
   const container = document.createElement("div");
   container.className = "page-topbar-container";
-  container.style.cssText = "display: flex; align-items: center; justify-content: space-between; padding: 24px 0; margin-bottom: 16px;";
+  container.style.cssText = "display: flex; align-items: center; justify-content: space-between; padding: 0; margin-bottom: 16px;";
 
-  // Left side: Title and subtitle
+  // Left side: Title and subtitle with badge
   const left = document.createElement("div");
   left.style.cssText = "flex: 1;";
 
@@ -28,30 +28,36 @@ export function renderPageTopbar({ title, subtitle, href = "/app", statusBadge }
   titleEl.style.cssText = "margin: 0 0 8px 0; font-size: 24px; font-weight: 600; color: var(--text);";
   left.appendChild(titleEl);
 
+  // Subtitle row with badge
   if (subtitle) {
-    const subtitleEl = document.createElement("div");
+    const subtitleRow = document.createElement("div");
+    subtitleRow.style.cssText = "display: flex; align-items: center; gap: 8px; flex-wrap: wrap;";
+
+    const subtitleEl = document.createElement("span");
     subtitleEl.textContent = subtitle;
-    subtitleEl.style.cssText = "margin: 0; font-size: 16px; color: var(--muted);";
-    left.appendChild(subtitleEl);
+    subtitleEl.style.cssText = "font-size: 16px; color: var(--muted);";
+    subtitleRow.appendChild(subtitleEl);
+
+    // Add status badge next to subtitle if provided
+    if (statusBadge && statusBadge.text) {
+      const badge = document.createElement("span");
+      badge.textContent = statusBadge.text;
+      // Use inline style if provided, otherwise fall back to className
+      if (statusBadge.style) {
+        badge.style.cssText = statusBadge.style;
+      } else if (statusBadge.className) {
+        badge.className = statusBadge.className;
+        badge.style.cssText = "font-size: 12px; font-weight: 600; padding: 4px 10px; border-radius: 12px; display: inline-flex; align-items: center;";
+      }
+      subtitleRow.appendChild(badge);
+    }
+
+    left.appendChild(subtitleRow);
   }
 
-  // Right side: Status badge and Return button
+  // Right side: Return button
   const right = document.createElement("div");
   right.style.cssText = "display: flex; align-items: center; gap: 16px;";
-
-  // Add status badge on the right if provided
-  if (statusBadge && statusBadge.text) {
-    const badge = document.createElement("span");
-    badge.textContent = statusBadge.text;
-    // Use inline style if provided, otherwise fall back to className
-    if (statusBadge.style) {
-      badge.style.cssText = statusBadge.style;
-    } else if (statusBadge.className) {
-      badge.className = statusBadge.className;
-      badge.style.cssText = "font-size: 12px; font-weight: 500; padding: 4px 10px; height: 24px; border-radius: 6px; display: inline-flex; align-items: center;";
-    }
-    right.appendChild(badge);
-  }
 
   // Return button
   const returnButton = document.createElement("a");

--- a/public/js/status-labels.js
+++ b/public/js/status-labels.js
@@ -12,9 +12,7 @@
 export function getStatusLabel(status, borrowerFirstName) {
   switch (status) {
     case "pending":
-      return borrowerFirstName
-        ? `Pending review by ${borrowerFirstName}`
-        : "Pending review";
+      return "Pending review";
     case "active":
       return "Active";
     case "overdue":

--- a/public/review.html
+++ b/public/review.html
@@ -131,7 +131,7 @@
   <!-- Logged in: show agreement review -->
   <div id="review-section" class="container hidden">
     <!-- Page header with title and return button -->
-    <div style="display:flex; align-items:center; justify-content:space-between; padding:24px 0 16px 0; margin-bottom:8px">
+    <div style="display:flex; align-items:center; justify-content:space-between; padding:0 0 16px 0; margin-bottom:8px">
       <div style="flex:1">
         <h1 style="margin:0; font-size:24px; font-weight:600; color:var(--text)">Review agreement</h1>
       </div>


### PR DESCRIPTION
…age/review pages

- Removed unused top spacing above page header
- Moved "Pending review" badge next to borrower name
- Simplified badge label (removed "by Bob" in top section)
- Unified header spacing for manage and review pages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Repositioned status badge to display inline with subtitle content instead of on the right side
  * Adjusted header and container spacing for improved layout
  * Streamlined pending status label presentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->