### PR TITLE
Add borrower-only payment due card

### DIFF
--- a/public/js/formatters.js
+++ b/public/js/formatters.js
@@ -56,3 +56,20 @@ function formatEuro0(euros, locale = EUR_LOCALE) {
 function formatEuro2(euros, locale = EUR_LOCALE) {
   return formatCurrency2((euros ?? 0) * 100, locale);
 }
+
+/**
+ * Format date for display
+ * @param {string|Date} isoDate - ISO date string or Date object
+ * @returns {string} Formatted date string (e.g., "Jan 15, 2025")
+ */
+function formatDate(isoDate) {
+  if (!isoDate) return '—';
+  const date = new Date(isoDate);
+  if (isNaN(date.getTime())) return '—';
+
+  return new Intl.DateTimeFormat(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: '2-digit'
+  }).format(date);
+}

--- a/public/review-details.html
+++ b/public/review-details.html
@@ -239,6 +239,13 @@
       </div>
     </div>
 
+    <!-- Next Payment Due Card (borrower-only, active agreements) -->
+    <div id="next-payment-card" class="card hidden" style="padding:20px; margin:16px 0">
+      <div style="color:var(--muted); font-size:14px; margin-bottom:8px">Next payment due</div>
+      <div id="next-payment-amount" style="font-size:28px; font-weight:600; color:var(--accent); margin-bottom:4px"></div>
+      <div style="color:var(--muted); font-size:14px">Due on <span id="next-payment-date"></span></div>
+    </div>
+
     <!-- Primary payment action button (for active agreements) - moved up -->
     <div id="payment-action-section" class="hidden" style="margin:16px 0">
       <button id="record-payment-btn" class="record-payment-btn" style="width:100%">Report Payment</button>
@@ -821,6 +828,9 @@
           document.getElementById('hardship-button-section').classList.remove('hidden');
         }
 
+        // Show next payment card for borrower on active agreements
+        showNextPaymentCard();
+
         // Show payment action button for active agreements
         if (agreement.status === 'active') {
           showPaymentActionButton();
@@ -843,6 +853,35 @@
         const overdueDays = Math.abs(diffDays);
         return `(${overdueDays} day${overdueDays === 1 ? '' : 's'} overdue)`;
       }
+    }
+
+    function showNextPaymentCard() {
+      // Only show for borrowers on active agreements
+      const isBorrower = agreement.borrower_user_id === currentUser.id;
+
+      if (!isBorrower || agreement.status !== 'active') {
+        document.getElementById('next-payment-card').classList.add('hidden');
+        return;
+      }
+
+      // Calculate next payment info
+      const nextPaymentInfo = getNextPaymentInfo(agreement);
+
+      if (!nextPaymentInfo) {
+        // No next payment due, hide the card
+        document.getElementById('next-payment-card').classList.add('hidden');
+        return;
+      }
+
+      // Populate the card
+      const amountFormatted = formatCurrency2(nextPaymentInfo.amount_cents);
+      const dateFormatted = formatDate(nextPaymentInfo.due_date);
+
+      document.getElementById('next-payment-amount').textContent = amountFormatted;
+      document.getElementById('next-payment-date').textContent = dateFormatted;
+
+      // Show the card
+      document.getElementById('next-payment-card').classList.remove('hidden');
     }
 
     async function populateDetails() {


### PR DESCRIPTION
Add a minimal, safe, read-only "Next payment due" summary card for borrowers on the Manage Agreement page. This is step 1 of a multi-step rollout to isolate the earlier modal bug.

Changes:
- Add formatDate() utility to public/js/formatters.js
- Add getNextPaymentInfo() calculation logic to public/js/derived-fields.js
- Add Next Payment Card HTML section to review-details.html (borrower-only, no buttons/modal)
- Add showNextPaymentCard() JavaScript to populate and show/hide card for borrowers only

Hard constraints enforced:
- No modal imports
- No button/link/CTA in the card
- No auto-open behavior
- Only visible to borrowers on active agreements with outstanding payments
- Card shows formatted amount and due date only

Role gating: Card displays ONLY when viewerRole === 'borrower' AND agreement.status === 'active'