### PR TITLE
fix(ui): remove unused #loading-card container causing top page spacing

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -43,6 +43,16 @@
   justify-content: center;
 }
 
+/* Fully collapse loading card when hidden to prevent space at top of page */
+#loading-card.hidden {
+  display: none !important;
+  visibility: hidden;
+  height: 0 !important;
+  min-height: 0 !important;
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
 #loading-text {
   color: #cbd5e1;
   text-align: center;


### PR DESCRIPTION
- Added CSS rule to fully collapse hidden loading-card element
- Eliminated unnecessary top margin and padding on manage/review pages
- Prevents 120px empty space when loading-card has hidden class

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed layout issue where the loading card would reserve space even when hidden, preventing unwanted spacing at the top of the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->