### PR TITLE
feat: add horizontal logo + text layout to login/signup header

### DIFF
--- a/public/login.html
+++ b/public/login.html
@@ -28,18 +28,22 @@
     @media (min-width: 900px) {
       .left-column{display:block}
     }
-    .left-logo-section{margin-bottom:32px}
-    .left-logo-section img{height:56px;width:auto;margin-bottom:12px}
-    .left-tagline{font-size:28px;font-weight:700;margin:16px 0 24px 0;line-height:1.2}
-    .left-features{list-style:none;padding:0;margin:0;font-size:14px;color:var(--muted)}
-    .left-features li{margin:12px 0;line-height:1.5}
+    /* Horizontal layout: logo beside text block */
+    .left-hero-section{display:flex;flex-direction:row;align-items:center;justify-content:flex-start;gap:40px;margin-bottom:32px}
+    .left-hero-section img{width:128px;height:128px;flex-shrink:0}
+    .left-text-block{flex:1;space-y:12px}
+    .left-tagline{font-size:28px;font-weight:600;margin:0 0 12px 0;line-height:1.3;color:var(--text)}
+    .left-description{font-size:14px;color:var(--muted);line-height:1.6;margin:0 0 16px 0;max-width:480px}
+    .left-features{list-style:disc;list-style-position:inside;padding:0;margin:0;font-size:13px;color:var(--muted)}
+    .left-features li{margin:6px 0;line-height:1.5}
 
     /* Mobile: show left content above form */
     .mobile-left-content{display:block;margin-bottom:32px;text-align:center}
-    .mobile-left-content .left-logo-section img{height:48px}
-    .mobile-left-content .left-tagline{font-size:20px;margin:12px 0 16px 0}
-    .mobile-left-content .left-features{font-size:13px}
-    .mobile-left-content .left-features li{margin:8px 0}
+    .mobile-left-content img{height:80px;width:80px;margin:0 auto 16px auto}
+    .mobile-left-content .left-tagline{font-size:22px;font-weight:600;margin:0 0 12px 0;line-height:1.3}
+    .mobile-left-content .left-description{font-size:13px;color:var(--muted);line-height:1.5;margin:0 0 16px 0;padding:0 16px}
+    .mobile-left-content .left-features{font-size:12px;text-align:left;max-width:360px;margin:0 auto}
+    .mobile-left-content .left-features li{margin:6px 0}
 
     @media (min-width: 900px) {
       .mobile-left-content{display:none}
@@ -78,29 +82,46 @@
   <div class="page-wrapper">
     <!-- Left column for desktop -->
     <div class="left-column">
-      <div class="left-logo-section">
-        <img src="/images/payfriends-logov2.png" alt="PayFriends logo" />
-        <h2 class="left-tagline">Pay friends, stay friends</h2>
-      </div>
-      <ul class="left-features">
-        <li>• Fair, trust-based loans between friends</li>
-        <li>• Automatic reminders and smart interest recalculation</li>
-        <li>• App handles chasing and negotiations — you stay friends</li>
-      </ul>
+      <section class="left-hero-section">
+        <!-- LEFT: logo -->
+        <img src="/logo-payfriends.svg" alt="PayFriends logo" />
+
+        <!-- RIGHT: text block -->
+        <div class="left-text-block">
+          <h1 class="left-tagline">PayFriends, stay friends</h1>
+
+          <p class="left-description">
+            PayFriends is a kind, smart fintech app — built to keep friends on good terms.<br />
+            It rewards early repayments, adjusts interest fairly, and finds solutions when paying gets hard.<br />
+            We handle the math and reminders — you keep the friendship.
+          </p>
+
+          <ul class="left-features">
+            <li>Fair, trust-based loans between friends</li>
+            <li>Automatic reminders and smart interest recalculation</li>
+            <li>App handles chasing and negotiations — you stay friends</li>
+          </ul>
+        </div>
+      </section>
     </div>
 
     <!-- Right column / main content -->
     <main class="container right-column">
     <!-- Mobile: show left content above form -->
     <div class="mobile-left-content">
-      <div class="left-logo-section">
-        <img src="/images/payfriends-logov2.png" alt="PayFriends logo" />
-        <h2 class="left-tagline">Pay friends, stay friends</h2>
-      </div>
+      <img src="/logo-payfriends.svg" alt="PayFriends logo" />
+      <h1 class="left-tagline">PayFriends, stay friends</h1>
+
+      <p class="left-description">
+        PayFriends is a kind, smart fintech app — built to keep friends on good terms.<br />
+        It rewards early repayments, adjusts interest fairly, and finds solutions when paying gets hard.<br />
+        We handle the math and reminders — you keep the friendship.
+      </p>
+
       <ul class="left-features">
-        <li>• Fair, trust-based loans between friends</li>
-        <li>• Automatic reminders and smart interest recalculation</li>
-        <li>• App handles chasing and negotiations — you stay friends</li>
+        <li>Fair, trust-based loans between friends</li>
+        <li>Automatic reminders and smart interest recalculation</li>
+        <li>App handles chasing and negotiations — you stay friends</li>
       </ul>
     </div>
 

--- a/public/logo-payfriends.svg
+++ b/public/logo-payfriends.svg
@@ -1,0 +1,21 @@
+<svg width="128" height="128" viewBox="0 0 128 128" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- PayFriends Logo - Smiley Coin -->
+
+  <!-- Outer circle (coin) -->
+  <circle cx="64" cy="64" r="60" fill="#3ddc97" stroke="#2bb67c" stroke-width="3"/>
+
+  <!-- Inner circle (shine effect) -->
+  <circle cx="64" cy="64" r="54" fill="#3ddc97" opacity="0.9"/>
+
+  <!-- Left eye -->
+  <circle cx="48" cy="54" r="6" fill="#0e1116"/>
+
+  <!-- Right eye -->
+  <circle cx="80" cy="54" r="6" fill="#0e1116"/>
+
+  <!-- Smile -->
+  <path d="M 40 70 Q 64 90 88 70" stroke="#0e1116" stroke-width="5" stroke-linecap="round" fill="none"/>
+
+  <!-- Coin shine effect -->
+  <ellipse cx="52" cy="38" rx="16" ry="12" fill="#ffffff" opacity="0.3"/>
+</svg>


### PR DESCRIPTION
Update the auth page header to display the PayFriends logo next to the tagline block in a horizontal layout on desktop, creating a more balanced and visually appealing hero section.

Changes:
- Desktop: logo (128x128) displays beside tagline + description + features
- Mobile: maintains stacked layout with logo centered above text
- Added enhanced description text explaining PayFriends value proposition
- Created placeholder SVG logo (smiley coin design)
- Logo is proportional to the ~4 lines of text height

The layout is fully responsive and maintains proper spacing and alignment across all screen sizes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI/UX Improvements**
  * Redesigned login page layout with a new horizontal hero section featuring updated branding presentation.
  * Enhanced mobile experience with improved responsive design and spacing adjustments.
  * Refined typography and color scheme for better visual hierarchy and readability across all screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->