### PR TITLE
Redesign auth hero to pic3 layout

### DIFF
--- a/public/login.html
+++ b/public/login.html
@@ -29,17 +29,26 @@
       .left-column{display:block}
     }
     /* Horizontal layout: logo beside text block */
-    .left-hero-section{display:flex;flex-direction:row;align-items:center;justify-content:flex-start;gap:40px;margin-bottom:32px}
-    .left-hero-section img{width:128px;height:128px;flex-shrink:0}
+    .left-hero-section{display:flex;flex-direction:row;align-items:center;justify-content:flex-start;gap:48px;margin-bottom:32px}
+    .left-hero-section img{width:144px;height:144px;flex-shrink:0;user-select:none;-webkit-user-drag:none;pointer-events:none}
+    @media (min-width: 1200px) {
+      .left-hero-section img{width:160px;height:160px}
+    }
     .left-text-block{flex:1;space-y:12px}
-    .left-tagline{font-size:28px;font-weight:600;margin:0 0 12px 0;line-height:1.3;color:var(--text)}
-    .left-description{font-size:14px;color:var(--muted);line-height:1.6;margin:0 0 16px 0;max-width:480px}
+    .left-tagline{font-size:32px;font-weight:600;margin:0 0 12px 0;line-height:1.25;color:var(--text);letter-spacing:-0.02em}
+    @media (min-width: 1200px) {
+      .left-tagline{font-size:36px}
+    }
+    .left-description{font-size:14px;color:var(--muted);line-height:1.6;margin:0 0 16px 0;max-width:540px}
+    @media (min-width: 1200px) {
+      .left-description{font-size:15px}
+    }
     .left-features{list-style:disc;list-style-position:inside;padding:0;margin:0;font-size:13px;color:var(--muted)}
     .left-features li{margin:6px 0;line-height:1.5}
 
     /* Mobile: show left content above form */
     .mobile-left-content{display:block;margin-bottom:32px;text-align:center}
-    .mobile-left-content img{height:80px;width:80px;margin:0 auto 16px auto}
+    .mobile-left-content img{height:80px;width:80px;margin:0 auto 16px auto;user-select:none;-webkit-user-drag:none;pointer-events:none}
     .mobile-left-content .left-tagline{font-size:22px;font-weight:600;margin:0 0 12px 0;line-height:1.3}
     .mobile-left-content .left-description{font-size:13px;color:var(--muted);line-height:1.5;margin:0 0 16px 0;padding:0 16px}
     .mobile-left-content .left-features{font-size:12px;text-align:left;max-width:360px;margin:0 auto}
@@ -88,12 +97,12 @@
 
         <!-- RIGHT: text block -->
         <div class="left-text-block">
-          <h1 class="left-tagline">PayFriends, stay friends</h1>
+          <h1 class="left-tagline">Pay friends, stay friends</h1>
 
           <p class="left-description">
-            PayFriends is a kind, smart fintech app — built to keep friends on good terms.<br />
-            It rewards early repayments, adjusts interest fairly, and finds solutions when paying gets hard.<br />
-            We handle the math and reminders — you keep the friendship.
+            PayFriends is a kind, smart fintech app, built to keep friends on good terms.
+            It motivates early repayments, adjusts interest fairly, and finds solutions when paying gets hard.
+            We handle the math and reminders, you keep the friendship.
           </p>
 
           <ul class="left-features">
@@ -110,12 +119,12 @@
     <!-- Mobile: show left content above form -->
     <div class="mobile-left-content">
       <img src="/logo-payfriends.svg" alt="PayFriends logo" />
-      <h1 class="left-tagline">PayFriends, stay friends</h1>
+      <h1 class="left-tagline">Pay friends, stay friends</h1>
 
       <p class="left-description">
-        PayFriends is a kind, smart fintech app — built to keep friends on good terms.<br />
-        It rewards early repayments, adjusts interest fairly, and finds solutions when paying gets hard.<br />
-        We handle the math and reminders — you keep the friendship.
+        PayFriends is a kind, smart fintech app, built to keep friends on good terms.
+        It motivates early repayments, adjusts interest fairly, and finds solutions when paying gets hard.
+        We handle the math and reminders, you keep the friendship.
       </p>
 
       <ul class="left-features">


### PR DESCRIPTION
- Increase logo size to 144px (desktop) and 160px (large screens) to match pic3 visual weight
- Update tagline from "PayFriends, stay friends" to "Pay friends, stay friends"
- Update description to use "motivates" instead of "rewards" for early repayments
- Enhance tagline typography: 32px -> 36px on large screens with improved letter-spacing
- Add user-select:none and -webkit-user-drag:none to prevent logo dragging
- Increase gap between logo and text to 48px for better breathing room
- Improve description max-width to 540px for better readability
- Keep Login/Sign Up tabs and form card unchanged
- Maintain responsive mobile layout with stacked elements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined layout spacing and hero image sizing for improved visual hierarchy
  * Enhanced typography scaling and responsive design for better readability across devices
  * Updated product messaging and copy for improved clarity and consistent tone
  * Added accessibility improvements to prevent accidental image selection and dragging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->