### PR TITLE
Fix borrower avatar to show lender counterparty

### DIFF
--- a/public/review-details.html
+++ b/public/review-details.html
@@ -1414,13 +1414,27 @@
       }
       document.getElementById('agreement-summary-line3').textContent = summaryLine3;
 
-      // Create and insert borrower avatar (always show borrower)
+      // Create and insert counterparty avatar (lender for borrower, borrower for lender)
       let avatarHtml = '';
-      if (agreement.borrower_profile_picture && agreement.borrower_user_id) {
-        avatarHtml = `<div class="user-avatar size-xl"><img src="/api/profile/picture/${agreement.borrower_user_id}" class="user-avatar-image" /></div>`;
+      let counterpartyName, counterpartyUserId, counterpartyHasProfilePicture;
+
+      if (isBorrower) {
+        // Borrower is viewing → show lender avatar
+        counterpartyName = lenderName;
+        counterpartyUserId = agreement.lender_user_id;
+        counterpartyHasProfilePicture = agreement.lender_profile_picture;
       } else {
-        const initials = getInitials(borrowerName);
-        const colorClass = getAvatarColor(borrowerName);
+        // Lender is viewing (or fallback) → show borrower avatar
+        counterpartyName = borrowerName;
+        counterpartyUserId = agreement.borrower_user_id;
+        counterpartyHasProfilePicture = agreement.borrower_profile_picture;
+      }
+
+      if (counterpartyHasProfilePicture && counterpartyUserId) {
+        avatarHtml = `<div class="user-avatar size-xl"><img src="/api/profile/picture/${counterpartyUserId}" class="user-avatar-image" /></div>`;
+      } else {
+        const initials = getInitials(counterpartyName);
+        const colorClass = getAvatarColor(counterpartyName);
         avatarHtml = `<div class="user-avatar size-xl"><div class="user-avatar-initials ${colorClass}">${initials}</div></div>`;
       }
       document.getElementById('summary-avatar').innerHTML = avatarHtml;


### PR DESCRIPTION
Previously, when a borrower viewed the manage or review pages, the avatar in the top green summary card incorrectly displayed the borrower's own avatar. This fix ensures that:
- When borrower is logged in: shows lender avatar (counterparty)
- When lender is logged in: shows borrower avatar (existing behavior)

The logic now determines the counterparty based on the current user's role and displays the appropriate avatar with profile picture or initials.

Fixes issue where borrower view didn't show the correct counterparty avatar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated avatar display in review details to accurately show your counterparty's profile. The correct counterparty avatar is now displayed based on your role, with profile pictures shown when available or falling back to initials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->