### PR TITLE
Add Fairness icon to Step 3 Interest screen

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -717,19 +717,53 @@
           </div>
           <div style="display:flex; justify-content:space-between; padding:8px 0; border-top:1px solid rgba(255,255,255,0.08); margin-top:8px; padding-top:12px">
             <span style="color:var(--muted)">Total interest</span>
-            <span style="font-weight:600" id="total-interest-display">€ 0,00</span>
+            <span style="display:flex; align-items:center; justify-content:flex-end; gap:6px">
+              <span style="font-weight:600" id="total-interest-display">€ 0,00</span>
+              <svg viewBox="0 0 16 16" width="16" height="16" stroke="currentColor" fill="none" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" style="opacity:0.7; flex-shrink:0">
+                <path d="M14 8 A6 6 0 1 0 8 2" />
+                <path d="M14 8 L12 6 M14 8 L12 10" />
+                <path d="M5.5 10.5 L6.5 11.5 L10.5 11.5 L11.5 10.5" />
+                <path d="M6.5 11.5 L6.5 9.5 M10.5 11.5 L10.5 9.5" />
+              </svg>
+            </span>
           </div>
           <div style="display:flex; justify-content:space-between; padding:8px 0">
             <span style="color:var(--muted); font-weight:600">Total to repay</span>
-            <span style="font-weight:700; font-size:18px; color:var(--accent)" id="total-repay-display">€ 0,00</span>
+            <span style="display:flex; align-items:center; justify-content:flex-end; gap:6px">
+              <span style="font-weight:700; font-size:18px; color:var(--accent)" id="total-repay-display">€ 0,00</span>
+              <svg viewBox="0 0 16 16" width="16" height="16" stroke="currentColor" fill="none" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" style="opacity:0.7; flex-shrink:0">
+                <path d="M14 8 A6 6 0 1 0 8 2" />
+                <path d="M14 8 L12 6 M14 8 L12 10" />
+                <path d="M5.5 10.5 L6.5 11.5 L10.5 11.5 L11.5 10.5" />
+                <path d="M6.5 11.5 L6.5 9.5 M10.5 11.5 L10.5 9.5" />
+              </svg>
+            </span>
           </div>
-          <p style="margin:12px 0 0 0; color:var(--muted); font-size:12px; line-height:1.5">Interest is calculated only on the remaining balance — fair and transparent.</p>
+          <p style="margin:12px 0 8px 0; color:var(--muted); font-size:12px; line-height:1.5">Interest is calculated only on the remaining balance — fair and transparent.</p>
+          <p style="margin:8px 0 0 0; color:var(--muted); font-size:12px; line-height:1.5; display:flex; align-items:center; gap:4px; flex-wrap:wrap">
+            <span>Amounts marked with</span>
+            <svg viewBox="0 0 16 16" width="14" height="14" stroke="currentColor" fill="none" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" style="opacity:0.7; flex-shrink:0">
+              <path d="M14 8 A6 6 0 1 0 8 2" />
+              <path d="M14 8 L12 6 M14 8 L12 10" />
+              <path d="M5.5 10.5 L6.5 11.5 L10.5 11.5 L11.5 10.5" />
+              <path d="M6.5 11.5 L6.5 9.5 M10.5 11.5 L10.5 9.5" />
+            </svg>
+            <span>are calculated using the Fairness Between Friends rules.</span>
+          </p>
         </div>
 
         <!-- Fairness Between Friends (collapsible) -->
         <div style="margin:20px 0">
           <button onclick="toggleSection('fairness-step3-section')" class="secondary" style="width:100%; text-align:left; padding:12px 16px; font-size:14px; display:flex; justify-content:space-between; align-items:center">
-            <span>Fairness Between Friends</span>
+            <span style="display:flex; align-items:center; gap:8px">
+              <svg viewBox="0 0 16 16" width="16" height="16" stroke="currentColor" fill="none" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" style="flex-shrink:0">
+                <path d="M14 8 A6 6 0 1 0 8 2" />
+                <path d="M14 8 L12 6 M14 8 L12 10" />
+                <path d="M5.5 10.5 L6.5 11.5 L10.5 11.5 L11.5 10.5" />
+                <path d="M6.5 11.5 L6.5 9.5 M10.5 11.5 L10.5 9.5" />
+              </svg>
+              <span>Fairness Between Friends (How it Works)</span>
+            </span>
             <span id="fairness-step3-toggle">▼</span>
           </button>
           <div id="fairness-step3-section" class="hidden" style="background:#10151d; border:1px solid rgba(255,255,255,0.08); border-radius:0 0 8px 8px; padding:16px; margin-top:-1px">


### PR DESCRIPTION
Add a new FairnessIcon SVG to visually connect "Fairness Between Friends" rules to the loan summary numbers on the New Agreement Step 3 (Interest) screen.

Changes:
- Created inline FairnessIcon SVG with circular arrow + handshake design
- Added icon next to "Total interest" and "Total to repay" values in loan summary
- Added explanatory helper text: "Amounts marked with [icon] are calculated using the Fairness Between Friends rules"
- Updated "Fairness Between Friends" dropdown header to include icon and "(How it Works)" text

The icon uses:
- viewBox="0 0 16 16" with 16x16 default dimensions
- stroke="currentColor" with no fill for consistency with dark UI
- strokeWidth="1.5", strokeLinecap="round", strokeLinejoin="round"
- opacity:0.7 for subtle visual weight
- Responsive flex layout that wraps gracefully on smaller screens

Scope: Step 3 (Interest) only. This pattern will be reused elsewhere in a separate task.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added visual indicators (icons) next to totals for improved clarity
  * Inserted explanatory helper text referencing the calculation methodology
  * Enhanced the Fairness Between Friends section header with icons and improved labeling for better user navigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->