### PR TITLE
Redirect logged-in users from token review URL

### DIFF
--- a/server.js
+++ b/server.js
@@ -2327,15 +2327,21 @@ app.get('/review', (req, res) => {
     return res.sendFile(path.join(__dirname, 'public', 'review-invalid.html'));
   }
 
-  // Verify token exists
+  // Verify token exists and get agreement_id
   const invite = db.prepare(`
-    SELECT id FROM agreement_invites WHERE token = ?
+    SELECT id, agreement_id FROM agreement_invites WHERE token = ?
   `).get(token);
 
   if (!invite) {
     return res.sendFile(path.join(__dirname, 'public', 'review-invalid.html'));
   }
 
+  // If user is logged in, redirect to the canonical review page
+  if (req.user) {
+    return res.redirect(302, `/agreements/${invite.agreement_id}/review`);
+  }
+
+  // If user is NOT logged in, serve the token-based review/signup page
   res.sendFile(path.join(__dirname, 'public', 'review.html'));
 });
 


### PR DESCRIPTION
…eements/:id/review

When a user visits /review?token=... with an active session, they are now redirected (302) to the canonical internal review page (/agreements/:id/review) instead of seeing the signup page.

Logged-out users continue to see the existing "Sign up / log in to review this agreement" page on /review?token=..., preserving the current behavior.

This ensures logged-in users always use the unified internal review page, while maintaining the token-based signup flow for guests.