### PR TITLE
Fix avatar overlap in agreement summary card

### DIFF
--- a/public/review-details.html
+++ b/public/review-details.html
@@ -158,6 +158,9 @@
     .user-avatar-initials.color-5{background:#10b981}
     .user-avatar-initials.color-6{background:#3b82f6}
     .user-avatar-initials.color-7{background:#14b8a6}
+    /* Override avatar margins inside summary section to allow overlap */
+    #summary-section #summary-avatar-lender > *,
+    #summary-section #summary-avatar-borrower > * {margin:0 !important}
     .counterparty-cell{display:flex; align-items:center; gap:10px}
     .due-date-overdue{color:#f87171}
     .due-date-upcoming{color:var(--muted)}


### PR DESCRIPTION
Add CSS override to remove margins from avatar components inside the summary card. This allows the negative margin on the borrower avatar to work properly, creating the desired 16px overlap effect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced avatar display in the review details section, enabling visual overlap between lender and borrower avatars for improved space efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->