### PR TITLE
Create heart-handshake icon variants for Step 3

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -699,6 +699,64 @@
             <path d="M4 11 L6 9 L8 10 L10 9 L12 11" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
             <path d="M3 7 A5.5 5.5 0 0 1 13 7" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
           </symbol>
+
+          <!-- Heart-Handshake Icon Variants (design exploration) -->
+
+          <!-- V1: Classic heart shape with handshake gesture at base -->
+          <symbol id="fairness-heart-v1" viewBox="0 0 16 16">
+            <path d="M8 13.5 L4.5 10 C3 8.5 3 6.5 4 5.5 C4.8 4.7 6 4.5 7 5.2 L8 6 L9 5.2 C10 4.5 11.2 4.7 12 5.5 C13 6.5 13 8.5 11.5 10 L8 13.5 Z" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            <path d="M6 9.5 L7 8.5 M10 9.5 L9 8.5" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+          </symbol>
+
+          <!-- V2: Geometric heart with minimal handshake lines -->
+          <symbol id="fairness-heart-v2" viewBox="0 0 16 16">
+            <path d="M8 13 L4 9 C2.5 7.5 2.5 5.5 4 4 C5 3 6.5 3 7.5 4 L8 4.5 L8.5 4 C9.5 3 11 3 12 4 C13.5 5.5 13.5 7.5 12 9 L8 13" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+            <line x1="6" y1="8" x2="7.5" y2="8" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+            <line x1="10" y1="8" x2="8.5" y2="8" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+          </symbol>
+
+          <!-- V3: Rounded heart with finger grip detail -->
+          <symbol id="fairness-heart-v3" viewBox="0 0 16 16">
+            <path d="M8 13 C8 13 3.5 9.5 3.5 6.5 C3.5 4.5 5 3 6.5 3 C7.3 3 8 3.5 8 3.5 C8 3.5 8.7 3 9.5 3 C11 3 12.5 4.5 12.5 6.5 C12.5 9.5 8 13 8 13" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            <path d="M6.5 7.5 L7 8 L8 8 L9 8 L9.5 7.5" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+          </symbol>
+
+          <!-- V4: Angular heart with crossed hands -->
+          <symbol id="fairness-heart-v4" viewBox="0 0 16 16">
+            <path d="M8 13.5 L4 9.5 L4 6 C4 4.5 5 3.5 6.2 3.5 C7 3.5 7.5 4 8 4.5 C8.5 4 9 3.5 9.8 3.5 C11 3.5 12 4.5 12 6 L12 9.5 Z" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            <path d="M6 8 L8 9 L10 8" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+          </symbol>
+
+          <!-- V5: Soft curved heart with subtle clasp -->
+          <symbol id="fairness-heart-v5" viewBox="0 0 16 16">
+            <path d="M8 13.5 C8 13.5 3 10 3 6.5 C3 4.5 4.5 3 6 3 C7 3 7.8 3.5 8 4.2 C8.2 3.5 9 3 10 3 C11.5 3 13 4.5 13 6.5 C13 10 8 13.5 8 13.5" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            <ellipse cx="8" cy="8.5" rx="2" ry="1" fill="none" stroke="currentColor" stroke-width="1.5"/>
+          </symbol>
+
+          <!-- V6: Pointed heart with握手 symbol -->
+          <symbol id="fairness-heart-v6" viewBox="0 0 16 16">
+            <path d="M8 3.5 L8 4.5 M8 3.5 C7.5 3 6.5 2.5 5.5 3 C4 3.8 3.5 5.5 4 7.5 C4.5 9.5 8 13 8 13 M8 3.5 C8.5 3 9.5 2.5 10.5 3 C12 3.8 12.5 5.5 12 7.5 C11.5 9.5 8 13 8 13" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            <path d="M6 7 L7 8 L8 7.5 L9 8 L10 7" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+          </symbol>
+
+          <!-- V7: Asymmetric heart with one-sided handshake -->
+          <symbol id="fairness-heart-v7" viewBox="0 0 16 16">
+            <path d="M8 13.2 L4.2 9.5 C3 8.2 3 6.2 4 5.2 C5 4.2 6.5 4.2 7.5 5 L8 5.5 L8.5 5 C9.5 4.2 11 4.2 12 5.2 C13 6.2 13 8.2 11.8 9.5 L8 13.2" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+            <path d="M6.5 8.5 L8 9.5 L9.5 8.5" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+          </symbol>
+
+          <!-- V8: Compact heart with interlocked fingers -->
+          <symbol id="fairness-heart-v8" viewBox="0 0 16 16">
+            <path d="M8 12.5 L4.5 9 C3.5 8 3.5 6.5 4.2 5.5 C5 4.8 6 4.5 7 5 L8 5.8 L9 5 C10 4.5 11 4.8 11.8 5.5 C12.5 6.5 12.5 8 11.5 9 L8 12.5" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            <path d="M6.5 8 L7.5 8.8 L8.5 8" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            <path d="M9.5 8 L8.5 8.8 L7.5 8" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+          </symbol>
+
+          <!-- V9: Minimalist heart with single handshake line -->
+          <symbol id="fairness-heart-v9" viewBox="0 0 16 16">
+            <path d="M8 13 L4 9 C2.5 7.5 2.5 5 4 3.5 C5.5 2 7 2.5 8 3.5 C9 2.5 10.5 2 12 3.5 C13.5 5 13.5 7.5 12 9 L8 13" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            <line x1="5.5" y1="7.5" x2="10.5" y2="7.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+          </symbol>
         </svg>
 
         <div id="readonly-banner-3" class="hidden" style="background:rgba(250,204,21,0.1); border:1px solid rgba(250,204,21,0.3); border-radius:8px; padding:12px; margin-bottom:20px; font-size:14px; color:var(--text)">
@@ -800,6 +858,22 @@
                   <svg style="width:24px; height:24px"><use href="#fairness-icon-hands"/></svg>
                   <span style="font-size:12px; color:var(--muted)">C</span>
                 </div>
+              </div>
+            </div>
+
+            <!-- Heart-Handshake Icon Variants (design exploration) -->
+            <div style="border-top:1px solid rgba(255,255,255,0.08); padding-top:16px; margin-top:16px">
+              <p style="margin:0 0 12px 0; font-size:12px; color:var(--muted)">New Heart–Handshake Icon Options (design review only):</p>
+              <div style="display:grid; grid-template-columns:repeat(3, 1fr); gap:16px; place-items:center; padding:12px; border-radius:8px; border:1px solid rgba(255,255,255,0.08)">
+                <svg style="width:24px; height:24px"><use href="#fairness-heart-v1"/></svg>
+                <svg style="width:24px; height:24px"><use href="#fairness-heart-v2"/></svg>
+                <svg style="width:24px; height:24px"><use href="#fairness-heart-v3"/></svg>
+                <svg style="width:24px; height:24px"><use href="#fairness-heart-v4"/></svg>
+                <svg style="width:24px; height:24px"><use href="#fairness-heart-v5"/></svg>
+                <svg style="width:24px; height:24px"><use href="#fairness-heart-v6"/></svg>
+                <svg style="width:24px; height:24px"><use href="#fairness-heart-v7"/></svg>
+                <svg style="width:24px; height:24px"><use href="#fairness-heart-v8"/></svg>
+                <svg style="width:24px; height:24px"><use href="#fairness-heart-v9"/></svg>
               </div>
             </div>
           </div>


### PR DESCRIPTION
Added 9 minimal, stroke-only SVG icon variants exploring the "handshake forming a heart" metaphor for the Fairness Between Friends feature. Each variant offers a different stylistic interpretation:

- V1: Classic heart with handshake gesture at base
- V2: Geometric heart with minimal handshake lines
- V3: Rounded heart with finger grip detail
- V4: Angular heart with crossed hands
- V5: Soft curved heart with subtle clasp
- V6: Pointed heart with handshake symbol
- V7: Asymmetric heart with one-sided handshake
- V8: Compact heart with interlocked fingers
- V9: Minimalist heart with single handshake line

All icons are displayed in a 3x3 preview grid in the Step 3 Interest section's "Fairness Between Friends" collapsible panel, alongside the existing icon variants (A, B, C) for visual comparison. This is design-review only; no icons are activated in the UI yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multiple Heart-Handshake icon variant options
  * Added visual preview grid to display icon design choices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->