### PR TITLE
fix: reduce bullet list font size on landing page

### DIFF
--- a/public/login.html
+++ b/public/login.html
@@ -41,7 +41,7 @@
       color:var(--muted); line-height:1.6; margin:0 0 16px;
     }
     .hero ul{
-      color:var(--muted); margin:0; padding-left:18px;
+      color:var(--muted); margin:0; padding-left:18px; font-size:14px;
     }
     .hero li{margin:6px 0; line-height:1.5}
 


### PR DESCRIPTION
Set .hero ul font-size to 14px to prevent text from wrapping awkwardly into the auth card on the login/landing screen. Keeps heading and paragraph sizes unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Reduced font size for list items in the hero section to improve visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->