### PR TITLE
Fix autofill inputs, dropdown text color, and empty state wrapping

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -424,21 +424,21 @@
     <!-- Welcome card for first-time users with no agreements -->
     <section class="card" id="welcome-card" style="display:none; text-align:center; padding:48px 32px">
       <h2 style="margin:0 0 16px 0; font-size:28px">Welcome to PayFriends.app</h2>
-      <p style="color:var(--text); font-size:16px; line-height:1.6; max-width:700px; margin:0 auto 32px auto">
+      <p style="color:var(--text); font-size:15px; line-height:1.6; max-width:540px; margin:0 auto 32px auto">
         PayFriends takes over the awkward part of lending — reminding, chasing, negotiating and recalculating — so you don't have to be the debt collector for your friends.
       </p>
-      <div style="max-width:600px; margin:0 auto 32px auto; text-align:left">
+      <div style="max-width:540px; margin:0 auto 32px auto; text-align:left">
         <div style="display:flex; gap:12px; margin-bottom:16px">
           <div style="color:var(--accent); font-size:20px; flex-shrink:0">✓</div>
-          <div style="color:var(--text); font-size:15px">Create clear, written agreements for loans between friends.</div>
+          <div style="color:var(--text); font-size:14px">Create clear, written agreements for loans between friends.</div>
         </div>
         <div style="display:flex; gap:12px; margin-bottom:16px">
           <div style="color:var(--accent); font-size:20px; flex-shrink:0">✓</div>
-          <div style="color:var(--text); font-size:15px">Automatic fair recalculations when repayments are early, late, or different amounts.</div>
+          <div style="color:var(--text); font-size:14px">Automatic fair recalculations when repayments are early, late, or different amounts.</div>
         </div>
         <div style="display:flex; gap:12px">
           <div style="color:var(--accent); font-size:20px; flex-shrink:0">✓</div>
-          <div style="color:var(--text); font-size:15px">PayFriends negotiates new plans with the borrower when they have payment issues.</div>
+          <div style="color:var(--text); font-size:14px">PayFriends negotiates new plans with the borrower when they have payment issues.</div>
         </div>
       </div>
       <button onclick="toggleNewAgreement()" style="display:inline-flex; align-items:center; gap:8px; padding:14px 24px; width:auto; font-size:16px">
@@ -758,7 +758,7 @@
           <button onclick="toggleSection('fairness-step3-section')" class="secondary" style="width:100%; text-align:left; padding:12px 16px; font-size:14px; display:flex; justify-content:space-between; align-items:center">
             <div style="display:flex; align-items:center; gap:8px">
               <img src="/images/payfriends-handshake.svg" alt="Fairness Between Friends" style="width:18px; height:18px;" />
-              <span>Fairness Between Friends (How it Works)</span>
+              <span style="color:var(--accent)">Fairness Between Friends (How it Works)</span>
             </div>
             <span id="fairness-step3-toggle">▼</span>
           </button>

--- a/public/login.html
+++ b/public/login.html
@@ -87,6 +87,15 @@
     }
     input:focus{border-color:var(--accent); box-shadow:0 0 0 3px rgba(61,220,151,.15)}
     input::placeholder{color:#6e7785}
+    input:-webkit-autofill,
+    input:-webkit-autofill:hover,
+    input:-webkit-autofill:focus,
+    input:-webkit-autofill:active{
+      -webkit-background-clip:text;
+      -webkit-text-fill-color:var(--text);
+      transition:background-color 5000s ease-in-out 0s;
+      box-shadow:inset 0 0 20px 20px #10151d !important;
+    }
     button.primary{
       width:100%; padding:12px; border-radius:10px; border:0; margin-top:10px;
       background:var(--accent); color:#0d130f; font-weight:800; font-size:15px; cursor:pointer;


### PR DESCRIPTION
…ty state wrapping

1. Fix autofill white background on Login/Sign Up inputs
   - Add webkit-autofill CSS rules to login.html inline styles
   - Matches existing autofill behavior from shared-controls.css
   - Prevents white background flash on browser autofill

2. Make Fairness dropdown header text green
   - Add color:var(--accent) to "Fairness Between Friends (How it Works)" text
   - Matches the handshake icon color for visual consistency

3. Improve empty state text wrapping on /app dashboard
   - Reduce paragraph max-width from 700px to 540px
   - Decrease paragraph font-size from 16px to 15px
   - Reduce bullet text from 15px to 14px
   - Prevents awkward single-word line wrapping

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined typography in the Welcome card with adjusted font sizes for improved readability and optimized container widths for better layout
  * Enhanced the Fairness section label styling with accent color emphasis for improved visual hierarchy
  * Customized login form autofill styling to provide better visual consistency and override default browser appearance for a polished user experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->