### PR TITLE
feat: add soft fade-up animation and hover effect to hero card

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -73,3 +73,28 @@
   transform: translateY(-1px);
   transition: all 0.2s ease;
 }
+
+/* Hero card animation */
+@keyframes hero-card-fade-up {
+  0% {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.hero-card-animate {
+  animation: hero-card-fade-up 600ms ease-out;
+}
+
+.hero-card-hover {
+  transition: transform 200ms ease-out, box-shadow 200ms ease-out;
+}
+
+.hero-card-hover:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.35);
+}

--- a/public/login.html
+++ b/public/login.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>PayFriends — Login</title>
+  <link rel="stylesheet" href="/css/app.css" />
   <style>
     :root{
       --bg:#0e1116; --card:#151a21; --text:#e6eef6; --muted:#a7b0bd; --accent:#3ddc97;
@@ -114,7 +115,7 @@
 <body>
   <div class="page">
     <!-- HERO (single instance, responsive) -->
-    <section class="hero" aria-labelledby="pf-hero-title">
+    <section class="hero hero-card-animate hero-card-hover" aria-labelledby="pf-hero-title">
       <h1 id="pf-hero-title">Pay friends, stay friends</h1>
       <div class="hero-row">
         <!-- Use YOUR existing PNG only -->


### PR DESCRIPTION
Add gentle keyframe animation that fades in and moves the hero section up 12px on page load (600ms ease-out). Include subtle hover effect with 4px lift and enhanced shadow for modern fintech feel.

- Add hero-card-fade-up keyframes to app.css
- Add hero-card-animate and hero-card-hover utility classes
- Apply animation classes to hero section in login.html
- Link app.css stylesheet to login page