### PR TITLE
Refine auth layout with placeholders and hero text

### DIFF
--- a/public/login.html
+++ b/public/login.html
@@ -39,12 +39,12 @@
     }
     .hero-copy{max-width:600px}
     .hero p{
-      color:var(--muted); line-height:1.6; margin:0 0 16px;
+      color:var(--muted); line-height:1.6; margin:0 0 16px; font-size:14px;
     }
     .hero ul{
       color:var(--muted); margin:0; padding-left:18px; font-size:14px;
     }
-    .hero li{margin:6px 0; line-height:1.5; font-size:14px}
+    .hero li{margin:6px 0; line-height:1.5}
 
     /* Mobile hero stack */
     @media (max-width:899px){
@@ -62,6 +62,8 @@
       border-radius:16px;
       padding:24px;
       box-shadow:0 10px 30px rgba(0,0,0,.35);
+      max-width:540px;
+      margin:0 auto;
     }
     @media (min-width:900px){ .card{padding:28px} }
     .tabs{
@@ -109,6 +111,12 @@
     .mini{margin-top:16px; text-align:center; color:#8691a1; font-size:12px}
     .mini a{color:#9fdcc0; text-decoration:none}
     .mini a:hover{text-decoration:underline}
+
+    /* Screen reader only utility */
+    .sr-only{
+      position:absolute; width:1px; height:1px; padding:0; margin:-1px;
+      overflow:hidden; clip:rect(0,0,0,0); white-space:nowrap; border-width:0;
+    }
   </style>
 </head>
 <body>
@@ -121,14 +129,14 @@
         <img class="hero-logo" src="/images/payfriends-logov2.png" alt="PayFriends logo" />
         <div class="hero-copy">
           <p>
-            PayFriends is a kind, smart fintech app — built to keep friends on good terms.
+            PayFriends is a kind, smart fintech app built to keep friends on good terms.
             It rewards early repayments, adjusts interest fairly, and finds solutions when paying gets hard.
-            We handle the math and reminders — you keep the friendship.
+            We handle the math and reminders, you keep the friendship.
           </p>
           <ul>
             <li>Fair, trust-based loans between friends</li>
             <li>Automatic reminders and smart interest recalculation</li>
-            <li>App handles chasing and negotiations — you stay friends</li>
+            <li>App handles chasing and negotiations so you stay friends</li>
           </ul>
         </div>
       </div>
@@ -148,12 +156,12 @@
         <h2 style="margin:0 0 8px">Login</h2>
         <form id="login-form" novalidate>
           <div class="row">
-            <label for="login-email">Email</label>
-            <input id="login-email" name="email" type="email" placeholder="lender@example.com" required autocomplete="username" />
+            <label for="login-email" class="sr-only">Email</label>
+            <input id="login-email" name="email" type="email" placeholder="you@example.com" required autocomplete="username" />
           </div>
           <div class="row">
-            <label for="login-password">Password</label>
-            <input id="login-password" name="password" type="password" placeholder="••••••••" required autocomplete="current-password" />
+            <label for="login-password" class="sr-only">Password</label>
+            <input id="login-password" name="password" type="password" placeholder="Password" required autocomplete="current-password" />
           </div>
           <button type="submit" class="primary">Login</button>
           <p id="login-status" class="status" role="status" aria-live="polite"></p>
@@ -165,16 +173,16 @@
         <h2 style="margin:0 0 8px">Create your account</h2>
         <form id="signup-form" novalidate>
           <div class="row">
-            <label for="signup-fullname">Full legal name (as on passport)</label>
-            <input id="signup-fullname" name="fullName" type="text" placeholder="Jane Smith" required />
+            <label for="signup-fullname" class="sr-only">Full legal name (as on passport)</label>
+            <input id="signup-fullname" name="fullName" type="text" placeholder="Your full name" required />
           </div>
           <div class="row">
-            <label for="signup-email">Email</label>
+            <label for="signup-email" class="sr-only">Email</label>
             <input id="signup-email" name="email" type="email" placeholder="you@example.com" required autocomplete="email" />
           </div>
           <div class="row">
-            <label for="signup-password">Password</label>
-            <input id="signup-password" name="password" type="password" placeholder="Minimum 6 characters" required autocomplete="new-password" />
+            <label for="signup-password" class="sr-only">Password</label>
+            <input id="signup-password" name="password" type="password" placeholder="Password" required autocomplete="new-password" />
           </div>
           <button type="submit" class="primary">Create account</button>
           <p id="signup-status" class="status" role="status" aria-live="polite"></p>


### PR DESCRIPTION
- Add sr-only utility for accessible but visually hidden labels
- Update login/signup forms to use placeholders instead of visible labels
- Widen auth card from implicit width to max-width:540px for better proportions
- Reduce hero body text to font-size:14px for lighter, less cramped appearance
- Remove long dash characters from hero copy, replace with commas and simple phrasing