### PR TITLE
Balance login page layout with 60/40 split

### DIFF
--- a/public/login.html
+++ b/public/login.html
@@ -17,14 +17,23 @@
       min-height:100vh; display:flex; align-items:center; justify-content:center;
     }
     .page{
-      width:100%; max-width:1200px; padding:32px 16px;
-      display:grid; grid-template-columns:1fr; gap:40px; align-items:center;
+      width:100%; max-width:1280px; padding:32px 16px;
+      display:flex; flex-direction:column; gap:40px; align-items:center;
     }
     @media (min-width:900px){
-      .page{grid-template-columns:1.1fr .9fr; gap:64px; padding:48px;}
+      .page{
+        flex-direction:row; align-items:flex-start; justify-content:space-between;
+        gap:64px; padding:96px 32px 64px;
+      }
     }
 
     /* HERO */
+    .hero{
+      flex:0 0 auto; width:100%;
+    }
+    @media (min-width:900px){
+      .hero{flex:0 0 60%; width:auto;}
+    }
     .hero h1{
       margin:0 0 16px; font-size:40px; line-height:1.15; font-weight:700;
       letter-spacing:-0.02em;
@@ -37,7 +46,7 @@
       filter: drop-shadow(0 6px 14px rgba(0,0,0,.35));
       margin-left:24px; margin-top:24px;
     }
-    .hero-copy{max-width:600px}
+    .hero-copy{max-width:640px}
     .hero p{
       color:var(--muted); line-height:1.6; margin:0 0 16px; font-size:14px;
     }
@@ -64,8 +73,11 @@
       box-shadow:0 10px 30px rgba(0,0,0,.35);
       max-width:540px;
       margin:0 auto;
+      flex:0 0 auto; width:100%;
     }
-    @media (min-width:900px){ .card{padding:28px} }
+    @media (min-width:900px){
+      .card{padding:28px; flex:0 0 40%; width:auto; max-width:640px; margin:0;}
+    }
     .tabs{
       display:flex; gap:12px; border-bottom:1px solid var(--card-border);
       margin:0 0 16px;


### PR DESCRIPTION
- Change main container to flexbox with max-width 1280px (max-w-6xl equivalent)
- Hero section now uses 60% width with wider text block (640px max-width)
- Auth card now uses 40% width with increased max-width (640px)
- Better vertical spacing with pt-24 (96px) and pb-16 (64px) equivalent
- Improved horizontal gap between sections (64px)
- Layout now sits nicely centered with balanced proportions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive layout of the login page with enhanced scaling across mobile and desktop viewports.
  * Optimized container sizing, padding, and alignment for better visual presentation at different screen sizes.
  * Enhanced spacing and proportions of page elements for improved usability across all breakpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->