### PR TITLE
Hide worst case scenario for loans under 6000 EUR

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -928,8 +928,8 @@
           </label>
         </div>
 
-        <!-- Worst-case scenario -->
-        <div style="margin:24px 0">
+        <!-- Worst-case scenario (only shown for loans >= 6000 EUR) -->
+        <div id="worst-case-scenario-container" style="margin:24px 0">
           <div style="display:flex; align-items:center; gap:12px; margin-bottom:8px">
             <label class="toggle-switch">
               <input type="checkbox" id="debt-collection-clause" checked />
@@ -1129,6 +1129,10 @@
       inviteUrl: '',
       agreementSent: false
     };
+
+    // Worst case scenario is only shown for loans from 6,000 EUR and higher,
+    // since debt collectors and legal escalation rarely make sense below this amount.
+    const WORST_CASE_MIN_AMOUNT_EUR = 6000;
 
     // Currency formatters are loaded from /js/formatters.js
     // - formatCurrency0(cents) - for My Agreements table (no decimals, nl-NL locale)
@@ -1820,6 +1824,36 @@
       } else {
         // For one-time payment, update the one-time estimate
         updateOneTimeEstimate();
+      }
+
+      // Also update worst case scenario visibility whenever amount changes
+      updateWorstCaseVisibility();
+    }
+
+    // Update visibility of worst case scenario option based on loan amount
+    function updateWorstCaseVisibility() {
+      const amountInput = document.getElementById('amount');
+      if (!amountInput) return;
+
+      const amountValue = amountInput.value;
+      const cleanAmount = amountValue.replace(/[.,]/g, '');
+      const amountNum = parseFloat(cleanAmount) || 0;
+
+      const container = document.getElementById('worst-case-scenario-container');
+      const checkbox = document.getElementById('debt-collection-clause');
+
+      if (!container) return;
+
+      const showWorstCase = amountNum >= WORST_CASE_MIN_AMOUNT_EUR;
+
+      if (showWorstCase) {
+        container.style.display = '';
+      } else {
+        container.style.display = 'none';
+        // Clear the checkbox when hidden
+        if (checkbox) {
+          checkbox.checked = false;
+        }
       }
     }
 
@@ -2653,6 +2687,9 @@
       }
 
       goToStep(4);
+
+      // Update worst case scenario visibility based on loan amount
+      updateWorstCaseVisibility();
     }
 
     // Navigate to summary
@@ -2691,7 +2728,14 @@
       }
 
       wizardData.proofRequired = document.getElementById('proof-required').checked;
-      wizardData.debtCollectionClause = document.getElementById('debt-collection-clause').checked;
+
+      // Only include debt collection clause if amount is >= 6000 EUR
+      const amountEur = wizardData.amount || 0;
+      if (amountEur >= WORST_CASE_MIN_AMOUNT_EUR) {
+        wizardData.debtCollectionClause = document.getElementById('debt-collection-clause').checked;
+      } else {
+        wizardData.debtCollectionClause = false;
+      }
 
       goToStep(5);
       updateSummary();
@@ -3049,7 +3093,8 @@
           reminderMode: wizardData.reminderMode,
           reminderOffsets: wizardData.reminderOffsets,
           proofRequired: wizardData.proofRequired,
-          debtCollectionClause: wizardData.debtCollectionClause
+          // Only include debt collection clause if amount >= 6000 EUR
+          debtCollectionClause: (wizardData.amount >= WORST_CASE_MIN_AMOUNT_EUR) ? wizardData.debtCollectionClause : false
         };
 
         // Add installment-specific fields if applicable

--- a/server.js
+++ b/server.js
@@ -835,6 +835,13 @@ app.post('/api/agreements', requireAuth, (req, res) => {
     return res.status(400).json({ error: 'Amount must be a positive number.' });
   }
 
+  // Worst case scenario (debt collection clause) is only allowed for loans >= 6000 EUR (600000 cents)
+  const WORST_CASE_MIN_AMOUNT_CENTS = 600000; // 6000 EUR
+  if (debtCollectionClause && amountCents < WORST_CASE_MIN_AMOUNT_CENTS) {
+    // Silently ignore the flag for small loans instead of rejecting the request
+    debtCollectionClause = false;
+  }
+
   // Allow past dates for existing loans (no validation needed)
 
   const createdAt = new Date().toISOString();

--- a/test/worst-case-threshold.test.js
+++ b/test/worst-case-threshold.test.js
@@ -1,0 +1,158 @@
+/**
+ * Unit tests for worst case scenario threshold validation
+ * Run with: node test/worst-case-threshold.test.js
+ *
+ * This test suite validates that the worst case scenario (debt collection clause)
+ * is only enabled for loans of 6,000 EUR or more.
+ */
+
+const assert = require('assert');
+
+console.log('Running worst case scenario threshold tests...\n');
+
+// Test constants
+const WORST_CASE_MIN_AMOUNT_EUR = 6000;
+const WORST_CASE_MIN_AMOUNT_CENTS = 600000;
+
+// Simulate the frontend logic
+function shouldShowWorstCaseOption(amountEur) {
+  return amountEur >= WORST_CASE_MIN_AMOUNT_EUR;
+}
+
+// Simulate the backend validation logic
+function validateDebtCollectionClause(amountCents, requestedValue) {
+  if (requestedValue && amountCents < WORST_CASE_MIN_AMOUNT_CENTS) {
+    // Silently ignore the flag for small loans
+    return false;
+  }
+  return requestedValue;
+}
+
+// Test 1: Frontend - Amount below threshold should hide the option
+console.log('Test 1: Frontend - Amount 5,999 EUR should hide worst case option');
+{
+  const amountEur = 5999;
+  const shouldShow = shouldShowWorstCaseOption(amountEur);
+
+  assert.strictEqual(shouldShow, false, 'Worst case option should be hidden for 5,999 EUR');
+  console.log('✓ Worst case option correctly hidden for 5,999 EUR');
+}
+
+// Test 2: Frontend - Amount at threshold should show the option
+console.log('\nTest 2: Frontend - Amount 6,000 EUR should show worst case option');
+{
+  const amountEur = 6000;
+  const shouldShow = shouldShowWorstCaseOption(amountEur);
+
+  assert.strictEqual(shouldShow, true, 'Worst case option should be shown for 6,000 EUR');
+  console.log('✓ Worst case option correctly shown for 6,000 EUR');
+}
+
+// Test 3: Frontend - Amount above threshold should show the option
+console.log('\nTest 3: Frontend - Amount 10,000 EUR should show worst case option');
+{
+  const amountEur = 10000;
+  const shouldShow = shouldShowWorstCaseOption(amountEur);
+
+  assert.strictEqual(shouldShow, true, 'Worst case option should be shown for 10,000 EUR');
+  console.log('✓ Worst case option correctly shown for 10,000 EUR');
+}
+
+// Test 4: Frontend - Edge case at 5,999.99 EUR
+console.log('\nTest 4: Frontend - Amount 5,999.99 EUR should hide worst case option');
+{
+  const amountEur = 5999.99;
+  const shouldShow = shouldShowWorstCaseOption(amountEur);
+
+  assert.strictEqual(shouldShow, false, 'Worst case option should be hidden for 5,999.99 EUR');
+  console.log('✓ Worst case option correctly hidden for 5,999.99 EUR');
+}
+
+// Test 5: Frontend - Edge case at 6,000.01 EUR
+console.log('\nTest 5: Frontend - Amount 6,000.01 EUR should show worst case option');
+{
+  const amountEur = 6000.01;
+  const shouldShow = shouldShowWorstCaseOption(amountEur);
+
+  assert.strictEqual(shouldShow, true, 'Worst case option should be shown for 6,000.01 EUR');
+  console.log('✓ Worst case option correctly shown for 6,000.01 EUR');
+}
+
+// Test 6: Backend - Reject debt collection for small loans
+console.log('\nTest 6: Backend - Amount 3,000 EUR with debt collection = true should be overridden to false');
+{
+  const amountCents = 300000; // 3,000 EUR
+  const requestedValue = true;
+  const result = validateDebtCollectionClause(amountCents, requestedValue);
+
+  assert.strictEqual(result, false, 'Backend should override debt collection to false for 3,000 EUR');
+  console.log('✓ Backend correctly overrides debt collection to false for 3,000 EUR');
+}
+
+// Test 7: Backend - Accept debt collection for large loans
+console.log('\nTest 7: Backend - Amount 6,000 EUR with debt collection = true should be accepted');
+{
+  const amountCents = 600000; // 6,000 EUR
+  const requestedValue = true;
+  const result = validateDebtCollectionClause(amountCents, requestedValue);
+
+  assert.strictEqual(result, true, 'Backend should accept debt collection for 6,000 EUR');
+  console.log('✓ Backend correctly accepts debt collection for 6,000 EUR');
+}
+
+// Test 8: Backend - Accept false value for small loans
+console.log('\nTest 8: Backend - Amount 3,000 EUR with debt collection = false should remain false');
+{
+  const amountCents = 300000; // 3,000 EUR
+  const requestedValue = false;
+  const result = validateDebtCollectionClause(amountCents, requestedValue);
+
+  assert.strictEqual(result, false, 'Backend should keep debt collection as false for 3,000 EUR');
+  console.log('✓ Backend correctly keeps debt collection as false for 3,000 EUR');
+}
+
+// Test 9: Backend - Edge case at exactly 599,999 cents (5,999.99 EUR)
+console.log('\nTest 9: Backend - Amount 5,999.99 EUR (599,999 cents) with debt collection = true should be overridden');
+{
+  const amountCents = 599999; // 5,999.99 EUR
+  const requestedValue = true;
+  const result = validateDebtCollectionClause(amountCents, requestedValue);
+
+  assert.strictEqual(result, false, 'Backend should override debt collection for 5,999.99 EUR');
+  console.log('✓ Backend correctly overrides debt collection for 5,999.99 EUR');
+}
+
+// Test 10: Backend - Edge case at exactly 600,000 cents (6,000.00 EUR)
+console.log('\nTest 10: Backend - Amount 6,000.00 EUR (600,000 cents) with debt collection = true should be accepted');
+{
+  const amountCents = 600000; // 6,000.00 EUR
+  const requestedValue = true;
+  const result = validateDebtCollectionClause(amountCents, requestedValue);
+
+  assert.strictEqual(result, true, 'Backend should accept debt collection for exactly 6,000.00 EUR');
+  console.log('✓ Backend correctly accepts debt collection for exactly 6,000.00 EUR');
+}
+
+// Test 11: Frontend - Small amounts (0, 100, 1000)
+console.log('\nTest 11: Frontend - Small amounts should all hide worst case option');
+{
+  const amounts = [0, 100, 1000, 2500, 5000];
+  amounts.forEach(amount => {
+    const shouldShow = shouldShowWorstCaseOption(amount);
+    assert.strictEqual(shouldShow, false, `Amount ${amount} EUR should hide worst case option`);
+  });
+  console.log('✓ All small amounts correctly hide worst case option');
+}
+
+// Test 12: Frontend - Large amounts (7000, 10000, 50000)
+console.log('\nTest 12: Frontend - Large amounts should all show worst case option');
+{
+  const amounts = [7000, 10000, 25000, 50000, 100000];
+  amounts.forEach(amount => {
+    const shouldShow = shouldShowWorstCaseOption(amount);
+    assert.strictEqual(shouldShow, true, `Amount ${amount} EUR should show worst case option`);
+  });
+  console.log('✓ All large amounts correctly show worst case option');
+}
+
+console.log('\n✓ All worst case scenario threshold tests passed!\n');


### PR DESCRIPTION
Only show the "Worst case scenario" (debt collection clause) option when the loan amount is at least 6,000 EUR. For smaller loans, the option is completely hidden from the UI and cannot be enabled.

Frontend changes (public/app.html):
- Add WORST_CASE_MIN_AMOUNT_EUR constant (6,000 EUR)
- Add updateWorstCaseVisibility() function to show/hide the option
- Call visibility update on amount changes and when navigating to step 4
- Clear debtCollectionClause flag when amount < 6,000 EUR
- Only include debtCollectionClause in API payload if amount >= 6,000 EUR

Backend changes (server.js):
- Add WORST_CASE_MIN_AMOUNT_CENTS constant (600,000 cents = 6,000 EUR)
- Validate and override debtCollectionClause to false for amounts < 6,000 EUR
- Prevents malicious or buggy clients from enabling debt collection on small loans

Tests (test/worst-case-threshold.test.js):
- Test frontend visibility logic for various amounts
- Test backend validation for various amounts
- Test edge cases (5,999.99 EUR, 6,000.00 EUR, 6,000.01 EUR)
- All 12 test cases pass

This ensures debt collectors and legal escalation are only offered for larger loans where they make economic sense.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The "Worst case scenario" feature is now available exclusively for loans of 6,000 EUR or higher
  * Debt collection eligibility is consistently enforced across all application flows based on loan amount thresholds
  * Enhanced visibility controls ensure feature availability updates dynamically as loan amounts change

<!-- end of auto-generated comment: release notes by coderabbit.ai -->