### PR TITLE
Fix Report Payment layout and add fairness helper

### DIFF
--- a/public/review-details.html
+++ b/public/review-details.html
@@ -287,10 +287,14 @@
 
       <div class="form-group">
         <label class="form-label" for="inline-payment-amount">Amount (EUR)</label>
-        <div style="display:flex; gap:8px; align-items:center">
-          <input type="number" id="inline-payment-amount" placeholder="e.g. 200" min="0" step="0.01" style="flex:1">
-          <button id="autofill-amount-btn" class="secondary" style="white-space:nowrap; padding:10px 14px; font-size:13px" title="Autofill with your next scheduled payment">Use next payment amount</button>
+        <div style="display:flex; gap:10px; align-items:center; flex-wrap:wrap">
+          <input type="number" id="inline-payment-amount" placeholder="e.g. 1 234,56" min="0" step="0.01" style="min-width:160px; max-width:220px; flex-shrink:0">
+          <button id="autofill-amount-btn" class="secondary" style="white-space:nowrap; padding:10px 14px; font-size:13px; flex-shrink:0" title="Autofill with your next scheduled payment">Use next payment amount</button>
         </div>
+        <p style="color:var(--muted); font-size:13px; margin:10px 0 0 0; line-height:1.6; display:flex; align-items:start; gap:4px">
+          <img src="/images/payfriends-handshake.svg" style="display:inline-block; height:16px; width:16px; margin-top:2px; flex-shrink:0" alt="PayFriends fairness icon" />
+          <span><strong>Fairness recalculations activated:</strong> Paying more than the due amount lowers interest and adjusts future installments. (Try a higher amount to see the changes.)</span>
+        </p>
         <p id="amount-helper-text" style="color:var(--muted); font-size:13px; margin:8px 0 0 0; line-height:1.5"></p>
       </div>
 


### PR DESCRIPTION
- Fix Amount input and "Use next payment amount" button layout:
  - Amount field now has min-width (160px) and max-width (220px) instead of flex:1
  - Button sized to content with flex-shrink:0
  - Both controls form a compact inline group with flex-wrap for mobile
  - Updated placeholder to show typical format (e.g. 1 234,56)

- Add fairness helper text below controls:
  - Includes PayFriends handshake icon
  - Explains fairness recalculation behavior
  - Styled consistently with existing helper texts

No functional changes, layout improvements only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the payment amount input field with a more flexible layout and clearer placeholder text showing formatting examples.
  * Added explanatory helper text that describes how fairness amounts are recalculated when paying more than the initially due amount.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->