### PR TITLE
Fix avatar image bug and redesign header layout

### DIFF
--- a/public/js/header.js
+++ b/public/js/header.js
@@ -335,12 +335,20 @@
     await loadActivityCount();
   }
 
+  /**
+   * Refresh user info (useful after profile updates like avatar upload)
+   */
+  async function refreshUserInfo() {
+    await loadUserInfo();
+  }
+
   // Export functions to global scope
   window.PayFriendsHeader = {
     initialize: initializeHeader,
     getCurrentUser: getCurrentUser,
     refreshActivityCount: refreshActivityCount,
-    updateActivityButton: updateActivityButton
+    updateActivityButton: updateActivityButton,
+    refreshUserInfo: refreshUserInfo
   };
 
 })();

--- a/public/profile.html
+++ b/public/profile.html
@@ -340,6 +340,11 @@
         currentUser.profile_picture = data.profilePictureUrl;
         displayProfilePicture(data.profilePictureUrl);
 
+        // Refresh header to show new avatar
+        if (window.PayFriendsHeader && window.PayFriendsHeader.refreshUserInfo) {
+          await window.PayFriendsHeader.refreshUserInfo();
+        }
+
         pictureStatus.textContent = '✓ Profile picture updated';
         pictureStatus.className = 'status success';
 
@@ -386,6 +391,11 @@
 
         currentUser.profile_picture = null;
         hideProfilePicture();
+
+        // Refresh header to show initials
+        if (window.PayFriendsHeader && window.PayFriendsHeader.refreshUserInfo) {
+          await window.PayFriendsHeader.refreshUserInfo();
+        }
 
         pictureStatus.textContent = '✓ Profile picture removed';
         pictureStatus.className = 'status success';


### PR DESCRIPTION
Fixed a bug where the header avatar would continue showing initials even after uploading a profile picture. The header now automatically refreshes when the user uploads or removes their avatar on the profile page.

Changes:
- Added refreshUserInfo() function to header.js to reload user data
- Profile page now calls this function after avatar upload/deletion
- Ensures header avatar stays in sync with profile changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Profile picture changes now trigger an automatic header refresh, ensuring your user information displays correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->