### PR TITLE
Personalize dashboard welcome with user name and wider text

### DIFF
--- a/public/app.html
+++ b/public/app.html
@@ -425,11 +425,11 @@
 
     <!-- Welcome card for first-time users with no agreements -->
     <section class="card" id="welcome-card" style="display:none; text-align:center; padding:48px 32px">
-      <h2 style="margin:0 0 16px 0; font-size:28px">Welcome to PayFriends.app</h2>
-      <p style="color:var(--text); font-size:15px; line-height:1.6; max-width:540px; margin:0 auto 32px auto">
+      <h2 id="welcome-heading" style="margin:0 0 16px 0; font-size:28px">Welcome to PayFriends.app</h2>
+      <p style="color:var(--text); font-size:15px; line-height:1.6; max-width:880px; margin:0 auto 32px auto">
         PayFriends takes over the awkward part of lending — reminding, chasing, negotiating and recalculating — so you don't have to be the debt collector for your friends.
       </p>
-      <div style="max-width:540px; margin:0 auto 32px auto; text-align:left">
+      <div style="max-width:880px; margin:0 auto 32px auto; text-align:left">
         <div style="display:flex; gap:12px; margin-bottom:16px">
           <div style="color:var(--accent); font-size:20px; flex-shrink:0">✓</div>
           <div style="color:var(--text); font-size:14px">Create clear, written agreements for loans between friends.</div>

--- a/public/components/agreements-table.js
+++ b/public/components/agreements-table.js
@@ -175,6 +175,21 @@ function renderAgreementsTable(agreements, currentUser, currentFilter = 'all', c
   if (welcomeCard && agreements.length === 0) {
     listSection.style.display = 'none';
     welcomeCard.style.display = 'block';
+
+    // Personalize welcome heading with user's first name
+    const welcomeHeading = document.getElementById('welcome-heading');
+    if (welcomeHeading && currentUser) {
+      const fullName = currentUser.full_name || currentUser.name || '';
+      const firstName = fullName.trim().split(/\s+/)[0] || '';
+
+      // Fallback to email prefix if first name is empty
+      const email = currentUser.email || '';
+      const fallbackName = email.includes('@') ? email.split('@')[0] : email;
+      const displayName = firstName || fallbackName || 'there';
+
+      welcomeHeading.textContent = `Welcome ${displayName} to PayFriends.app`;
+    }
+
     return;
   }
 


### PR DESCRIPTION
…name

- Increase max-width from 540px to 880px for welcome card text to use more horizontal space
- Add id="welcome-heading" to h2 for dynamic updates
- Personalize heading with user's first name (e.g., "Welcome Paul to PayFriends.app")
- Extract first name from full_name, fallback to email prefix if unavailable
- Maintain centered layout and responsive design