### PR TITLE
Fix one-time payment amount and label on manage agreement page

### DIFF
--- a/public/review-details.html
+++ b/public/review-details.html
@@ -269,7 +269,7 @@
       <div class="next-payment-container">
         <!-- LEFT/TOP: Payment info -->
         <div class="next-payment-info">
-          <div style="color:var(--muted); font-size:14px">Next payment due</div>
+          <div id="next-payment-label" style="color:var(--muted); font-size:14px">Next payment due</div>
           <div id="next-payment-amount" style="font-size:28px; font-weight:600; color:var(--accent); font-variant-numeric:tabular-nums"></div>
           <div style="color:var(--muted); font-size:14px; white-space:nowrap">Due on <span id="next-payment-date"></span></div>
         </div>
@@ -1028,6 +1028,11 @@
       const amountFormatted = formatCurrency2(nextPaymentInfo.amount_cents);
       const dateFormatted = formatDate(nextPaymentInfo.due_date);
 
+      // Set the label based on repayment type
+      const isOneTimeRepayment = agreement.repayment_type === 'one_time';
+      const labelText = isOneTimeRepayment ? 'Payment due' : 'Next payment due';
+
+      document.getElementById('next-payment-label').textContent = labelText;
       document.getElementById('next-payment-amount').textContent = amountFormatted;
       document.getElementById('next-payment-date').textContent = dateFormatted;
 

--- a/test/next-payment-info.test.js
+++ b/test/next-payment-info.test.js
@@ -1,0 +1,205 @@
+/**
+ * Unit tests for getNextPaymentInfo() - validates one-time vs installment payment calculations
+ * Run with: node test/next-payment-info.test.js
+ */
+
+const assert = require('assert');
+
+// Mock the required functions from schedule.js
+const {
+  generatePaymentDates,
+  buildRepaymentSchedule
+} = require('../public/js/schedule.js');
+
+// Make them globally available for derived-fields.js
+global.generatePaymentDates = generatePaymentDates;
+global.buildRepaymentSchedule = buildRepaymentSchedule;
+
+// Mock currency formatters for Node.js environment
+global.formatCurrency0 = (cents) => {
+  return new Intl.NumberFormat('nl-NL', { style: 'currency', currency: 'EUR', minimumFractionDigits: 0, maximumFractionDigits: 0 }).format(cents / 100);
+};
+global.formatCurrency2 = (cents) => {
+  return new Intl.NumberFormat('nl-NL', { style: 'currency', currency: 'EUR', minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(cents / 100);
+};
+
+// Load the function to test
+const { getNextPaymentInfo } = require('../public/js/derived-fields.js');
+
+console.log('Running getNextPaymentInfo() unit tests...\n');
+
+// Test 1: One-time repayment - amount should include interest
+console.log('Test 1: One-time repayment - amount includes interest');
+{
+  const agreement = {
+    status: 'active',
+    repayment_type: 'one_time',
+    amount_cents: 300000,           // Principal: €3,000.00
+    total_repay_amount: 3210.00,    // Total with interest: €3,210.00
+    total_paid_cents: 0,            // No payments yet
+    due_date: '2025-12-31',
+    interest_rate: 7
+  };
+
+  const result = getNextPaymentInfo(agreement);
+
+  assert.ok(result !== null, 'Should return payment info');
+  assert.strictEqual(result.amount_cents, 321000, 'Amount should be €3,210.00 (principal + interest)');
+  assert.strictEqual(result.due_date, '2025-12-31', 'Due date should match agreement due_date');
+  assert.strictEqual(result.schedule_row, null, 'One-time should not have schedule_row');
+
+  console.log(`✓ One-time payment amount: ${formatCurrency2(result.amount_cents)} (includes interest)`);
+}
+
+// Test 2: One-time repayment - without interest (total_repay_amount not set)
+console.log('\nTest 2: One-time repayment - no interest');
+{
+  const agreement = {
+    status: 'active',
+    repayment_type: 'one_time',
+    amount_cents: 300000,           // Principal: €3,000.00
+    total_repay_amount: null,       // No interest
+    total_paid_cents: 0,
+    due_date: '2025-12-31',
+    interest_rate: 0
+  };
+
+  const result = getNextPaymentInfo(agreement);
+
+  assert.ok(result !== null, 'Should return payment info');
+  assert.strictEqual(result.amount_cents, 300000, 'Amount should be €3,000.00 (principal only)');
+  assert.strictEqual(result.due_date, '2025-12-31', 'Due date should match agreement due_date');
+
+  console.log(`✓ One-time payment (no interest): ${formatCurrency2(result.amount_cents)}`);
+}
+
+// Test 3: One-time repayment - partial payment made
+console.log('\nTest 3: One-time repayment - partial payment');
+{
+  const agreement = {
+    status: 'active',
+    repayment_type: 'one_time',
+    amount_cents: 300000,           // Principal: €3,000.00
+    total_repay_amount: 3210.00,    // Total with interest: €3,210.00
+    total_paid_cents: 100000,       // Paid €1,000.00
+    due_date: '2025-12-31',
+    interest_rate: 7
+  };
+
+  const result = getNextPaymentInfo(agreement);
+
+  assert.ok(result !== null, 'Should return payment info');
+  assert.strictEqual(result.amount_cents, 221000, 'Amount should be €2,210.00 (remaining with interest)');
+
+  console.log(`✓ One-time payment (partial): ${formatCurrency2(result.amount_cents)} remaining`);
+}
+
+// Test 4: One-time repayment - fully paid
+console.log('\nTest 4: One-time repayment - fully paid');
+{
+  const agreement = {
+    status: 'active',
+    repayment_type: 'one_time',
+    amount_cents: 300000,
+    total_repay_amount: 3210.00,
+    total_paid_cents: 321000,       // Fully paid
+    due_date: '2025-12-31',
+    interest_rate: 7
+  };
+
+  const result = getNextPaymentInfo(agreement);
+
+  assert.strictEqual(result, null, 'Should return null when fully paid');
+
+  console.log('✓ One-time payment (fully paid): returns null');
+}
+
+// Test 5: Installment repayment - should use amortization schedule
+console.log('\nTest 5: Installment repayment - uses schedule');
+{
+  const agreement = {
+    status: 'active',
+    repayment_type: 'installments',
+    amount_cents: 400000,           // Principal: €4,000.00
+    total_paid_cents: 0,
+    interest_rate: 5,
+    installment_count: 6,
+    money_sent_date: '2025-01-01',
+    first_payment_date: '2025-02-01',
+    payment_frequency: 'monthly'
+  };
+
+  const result = getNextPaymentInfo(agreement);
+
+  assert.ok(result !== null, 'Should return payment info');
+  assert.ok(result.amount_cents > 0, 'Amount should be > 0');
+  assert.ok(result.schedule_row !== null, 'Installment should have schedule_row');
+  assert.strictEqual(result.row_index, 0, 'First payment should have row_index 0');
+
+  // For 6 monthly installments of €4,000 at 5%, each payment should be around €692
+  const expectedRange = { min: 680 * 100, max: 710 * 100 }; // €680 - €710
+  assert.ok(
+    result.amount_cents >= expectedRange.min && result.amount_cents <= expectedRange.max,
+    `Installment amount should be in range €680-€710, got ${formatCurrency2(result.amount_cents)}`
+  );
+
+  console.log(`✓ Installment payment (first): ${formatCurrency2(result.amount_cents)}`);
+}
+
+// Test 6: Installment repayment - after first payment
+console.log('\nTest 6: Installment repayment - second payment');
+{
+  const agreement = {
+    status: 'active',
+    repayment_type: 'installments',
+    amount_cents: 400000,
+    total_paid_cents: 69200,        // Paid first installment (~€692)
+    interest_rate: 5,
+    installment_count: 6,
+    money_sent_date: '2025-01-01',
+    first_payment_date: '2025-02-01',
+    payment_frequency: 'monthly'
+  };
+
+  const result = getNextPaymentInfo(agreement);
+
+  assert.ok(result !== null, 'Should return payment info');
+  assert.strictEqual(result.row_index, 1, 'Should be second payment (row_index 1)');
+
+  console.log(`✓ Installment payment (second): ${formatCurrency2(result.amount_cents)}`);
+}
+
+// Test 7: Inactive agreement should return null
+console.log('\nTest 7: Inactive agreement returns null');
+{
+  const agreement = {
+    status: 'completed',
+    repayment_type: 'one_time',
+    amount_cents: 300000,
+    total_repay_amount: 3210.00,
+    total_paid_cents: 0,
+    due_date: '2025-12-31'
+  };
+
+  const result = getNextPaymentInfo(agreement);
+
+  assert.strictEqual(result, null, 'Should return null for inactive agreement');
+
+  console.log('✓ Inactive agreement: returns null');
+}
+
+// Test 8: Null agreement should return null
+console.log('\nTest 8: Null agreement returns null');
+{
+  const result = getNextPaymentInfo(null);
+
+  assert.strictEqual(result, null, 'Should return null for null agreement');
+
+  console.log('✓ Null agreement: returns null');
+}
+
+console.log('\n✓ All tests passed!\n');
+console.log('Summary:');
+console.log('- One-time repayment: ✓ Correctly uses total_repay_amount (principal + interest)');
+console.log('- Installment repayment: ✓ Correctly uses amortization schedule');
+console.log('- Edge cases: ✓ Handles partial payments, fully paid, inactive, and null\n');


### PR DESCRIPTION
Previously, the "Next payment due" card on the Manage agreement page showed only the principal amount for one-time repayment agreements, not the total including interest. The label also said "Next payment due" which is misleading for one-time payments.

Changes:
- Fix amount calculation in getNextPaymentInfo() to use total_repay_amount for one-time repayment (includes principal + interest)
- Change label from "Next payment due" to "Payment due" for one-time repayment
- Keep installment behavior unchanged (uses amortization schedule)
- Add comprehensive test coverage for both one-time and installment cases

Example: For a €3,000 loan at 7% interest (total €3,210):
- Before: Card showed "Next payment due €3,000.00"
- After: Card shows "Payment due €3,210.00"

Fixes issue where one-time payment card amount didn't match the repayment schedule section's "total to repay" amount.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dynamic payment status label: displays "Payment due" for one-time repayments and "Next payment due" for installment plans.

* **Bug Fixes**
  * Improved next payment calculations to correctly handle fully paid repayments across both one-time and installment scenarios.

* **Tests**
  * Added comprehensive test coverage for next payment information calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->