### PR TITLE
Fix PayFriends renegotiation request screen UI

### DIFF
--- a/public/js/renegotiation.js
+++ b/public/js/renegotiation.js
@@ -11,31 +11,31 @@ const SOLUTION_TYPES = {
     {
       value: 'lower_installment',
       label: 'Lower my installment amount',
-      sublabel: 'Loan will extend',
+      sublabel: 'Reduce the amount per payment. The loan duration will increase to cover the full amount.',
       description: 'Reduce the amount per payment period. The loan duration will increase to cover the full amount.'
     },
     {
       value: 'postpone_upcoming',
       label: 'Postpone the upcoming installment',
-      sublabel: 'Push the next payment date',
+      sublabel: 'Delay your next payment by a few days or weeks. All future payments will shift accordingly.',
       description: 'Delay your next payment by a few days or weeks. All future payments will shift accordingly.'
     },
     {
       value: 'skip_upcoming',
       label: 'Skip the upcoming installment',
-      sublabel: 'Catch up later',
+      sublabel: 'Skip your next payment and spread the amount across future installments.',
       description: 'Skip your next payment and spread the amount across future installments or add one extra payment at the end.'
     },
     {
       value: 'temporary_pause',
       label: 'Temporary payment pause',
-      sublabel: 'Take a break',
+      sublabel: 'Pause payments for a short period. Resume afterwards with an adjusted schedule.',
       description: 'Pause payments for a short period (1-3 installments). Resume afterwards with adjusted schedule.'
     },
     {
       value: 'pay_part_adjust',
       label: 'Pay part now and adjust my schedule',
-      sublabel: 'Partial payment with new plan',
+      sublabel: 'Make a partial payment now and adjust the remaining installments to a more manageable amount.',
       description: 'Make a partial payment now and adjust the remaining installments to a more manageable amount.'
     }
   ],
@@ -48,7 +48,7 @@ const SOLUTION_TYPES = {
     },
     {
       value: 'split_repayment',
-      label: 'Split into smaller parts',
+      label: 'Split the repayment into smaller parts',
       sublabel: 'Turn the one-time amount into multiple smaller scheduled payments.',
       description: 'Convert the single payment into multiple smaller payments spread over time.'
     },
@@ -290,8 +290,7 @@ function buildSolutionTypeOptions(loanType, selectedType = null) {
                value="${option.value}" ${checked}>
         <label for="solution-${option.value}">
           <strong>${option.label}</strong>
-          ${option.sublabel ? `<span class="sublabel">${option.sublabel}</span>` : ''}
-          <div class="description">${option.description}</div>
+          ${option.sublabel ? `<div class="description">${option.sublabel}</div>` : ''}
         </label>
       </div>
     `;

--- a/public/review-details.html
+++ b/public/review-details.html
@@ -757,8 +757,21 @@
         </div>
 
         <div class="form-group">
-          <label class="form-label">Tell your friend what's going on (optional)</label>
-          <textarea id="renegotiation-note" rows="3" placeholder="I'm going through a tough time..."></textarea>
+          <label class="form-label">Tell your friend what's going on</label>
+          <select id="renegotiation-trouble-reason" style="width:100%; padding:12px; border-radius:8px; border:1px solid rgba(255,255,255,0.15); background:var(--bg); color:var(--text); font-size:14px">
+            <option value="">Select a reason...</option>
+            <option value="unexpected_expenses">Unexpected expenses</option>
+            <option value="income_delay">Income delay (salary, client, invoice, etc)</option>
+            <option value="budget_tight">My budget is tight this month</option>
+            <option value="prefer_not_to_say">I prefer not to say</option>
+            <option value="other">Other</option>
+          </select>
+          <small style="color:var(--muted); font-size:12px">Required</small>
+        </div>
+
+        <div class="form-group hidden" id="renegotiation-reason-other-container">
+          <label class="form-label">Explain in your own words (optional)</label>
+          <textarea id="renegotiation-reason-other" rows="3" placeholder="Tell your friend more about your situation..."></textarea>
         </div>
       </div>
 
@@ -768,7 +781,7 @@
         <div id="renegotiation-solution-types"></div>
       </div>
 
-      <button onclick="submitRenegotiationRequest()">Send renegotiation request</button>
+      <button id="renegotiation-submit-btn" onclick="submitRenegotiationRequest()">Send renegotiation request</button>
       <button class="secondary" onclick="cancelRenegotiationForm()">Cancel</button>
 
       <p class="status" id="renegotiation-initiation-status"></p>
@@ -2544,6 +2557,11 @@
       const solutionTypesContainer = document.getElementById('renegotiation-solution-types');
       solutionTypesContainer.innerHTML = window.RenegotiationModule.buildSolutionTypeOptions(loanType);
 
+      // Set button text with lender name
+      const lenderName = (agreement.lender_full_name || agreement.lender_name || agreement.lender_email).split(' ')[0];
+      const submitBtn = document.getElementById('renegotiation-submit-btn');
+      submitBtn.textContent = `Send renegotiation request to ${lenderName}`;
+
       // Scroll to form
       form.scrollIntoView({ behavior: 'smooth', block: 'start' });
     }
@@ -2568,7 +2586,6 @@
       const troubleReasonOther = document.getElementById('renegotiation-reason-other').value;
       const selectedType = document.querySelector('input[name="solution-type"]:checked')?.value;
       const canPayNowInput = document.getElementById('renegotiation-can-pay-now').value;
-      const note = document.getElementById('renegotiation-note').value;
 
       // Validate trouble reason (mandatory)
       if (!troubleReason) {
@@ -2593,7 +2610,7 @@
           agreementId,
           selectedType,
           canPayNowCents,
-          note,
+          null, // borrowerNote - no longer used
           troubleReason,
           troubleReasonOther
         );


### PR DESCRIPTION
- Replace optional reason textarea with required dropdown containing predefined reasons (unexpected expenses, income delay, budget tight, prefer not to say, other)
- Add optional "Other" textarea that appears when "Other" is selected from dropdown
- Update solutions section to show only single-line descriptions for both one-time and installment loans
- Update installment loan solution descriptions to be more concise and descriptive
- Fix one-time loan "Split" option label to match spec
- Update submit button to include lender name: "Send renegotiation request to <lender name>"
- Remove old optional note field from form submission

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Renegotiation requests now require selecting a trouble reason from predefined options, with an optional explanation field
  * Submit button now displays the lender's name for personalization

* **Improvements**
  * Expanded installment option descriptions from brief hints to detailed explanations, helping users better understand each repayment choice
  * Updated one renegotiation label for clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->