### PR TITLE
Fix renegotiation request flow UI and text

### DIFF
--- a/public/review-details.html
+++ b/public/review-details.html
@@ -747,7 +747,6 @@
             <option value="prefer_not_to_say">I prefer not to say</option>
             <option value="other">Other</option>
           </select>
-          <small style="color:var(--muted); font-size:12px">Required</small>
         </div>
 
         <div class="form-group hidden" id="renegotiation-reason-other-container">
@@ -2513,11 +2512,11 @@
       if (agreement.repayment_type === 'installments' && agreement.next_payment_amount_cents && agreement.next_payment_date) {
         const amount = formatCurrency2(agreement.next_payment_amount_cents);
         const date = new Date(agreement.next_payment_date).toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' });
-        expectedPaymentEl.textContent = `You are supposed to pay ${amount} on ${date}.`;
+        expectedPaymentEl.textContent = `Your next installment is ${amount}, due on ${date}. Let's see how we can adjust the plan.`;
       } else if (agreement.repayment_type !== 'installments' && agreement.amount_cents && agreement.due_date) {
         const amount = formatEuro0(agreement.amount_cents / 100);
         const date = new Date(agreement.due_date).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
-        expectedPaymentEl.textContent = `Full repayment due: ${amount} on ${date}`;
+        expectedPaymentEl.textContent = `You are supposed to pay ${amount} on ${date}.`;
       } else {
         expectedPaymentEl.textContent = 'You are having difficulty making the scheduled payment.';
       }
@@ -2552,7 +2551,7 @@
 
       // Set button text with lender name
       const submitBtn = document.getElementById('renegotiation-submit-btn');
-      submitBtn.textContent = `Send request to ${lenderName}`;
+      submitBtn.textContent = `Send new plan proposal to ${lenderName}`;
 
       // Scroll to form
       form.scrollIntoView({ behavior: 'smooth', block: 'start' });


### PR DESCRIPTION
- Update installment loan banner to show specific next payment details: "Your next installment is {amount}, due on {date}. Let's see how we can adjust the plan."
- Standardize one-time loan banner text format
- Remove redundant "Required" label from dropdown (field is still validated)
- Update button text to clearer "Send new plan proposal to {lenderName}"

These changes improve clarity and user experience in the borrower difficulty flow while maintaining all validation and branching logic for installment vs one-time loans.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Experience Improvements**
  * Enhanced renegotiation request flow with clearer messaging and updated button labels
  * Refined guidance text for both installment and non-installment repayment scenarios
  * Added explanatory text to help users understand the benefits of immediate payment options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->