### PR TITLE
Fix installment loan banner text in renegotiation flow

### DIFF
--- a/public/review-details.html
+++ b/public/review-details.html
@@ -2512,7 +2512,7 @@
       if (agreement.repayment_type === 'installments' && agreement.next_payment_amount_cents && agreement.next_payment_date) {
         const amount = formatCurrency2(agreement.next_payment_amount_cents);
         const date = new Date(agreement.next_payment_date).toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' });
-        expectedPaymentEl.textContent = `Your next installment is ${amount}, due on ${date}. Let's see how we can adjust the plan.`;
+        expectedPaymentEl.textContent = `Your next installment is ${amount}, due on ${date}.`;
       } else if (agreement.repayment_type !== 'installments' && agreement.amount_cents && agreement.due_date) {
         const amount = formatEuro0(agreement.amount_cents / 100);
         const date = new Date(agreement.due_date).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });


### PR DESCRIPTION
Remove the extra sentence "Let's see how we can adjust the plan." from the installment loan banner on the borrower renegotiation flow.

The banner now shows just:
"Your next installment is {amount}, due on {date}."

One-time loan banners remain unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Simplified installment payment notification messaging by removing an additional guidance sentence, now displaying only the next installment amount and due date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->